### PR TITLE
IN-326 add elasticache cluster for cacheing

### DIFF
--- a/lambda_functions/v1/requirements/requirements.txt
+++ b/lambda_functions/v1/requirements/requirements.txt
@@ -1,4 +1,5 @@
-#Update this date to trigger update of layers: 290416
+#Update this date to trigger update of layers: 290418
 Flask
 Werkzeug
 pyjwt
+redis

--- a/terraform/environment/dns.tf
+++ b/terraform/environment/dns.tf
@@ -49,3 +49,12 @@ resource "aws_route53_record" "environment_record" {
     zone_id                = aws_api_gateway_domain_name.lpa_data.regional_zone_id
   }
 }
+
+resource "aws_route53_record" "lpa_redis" {
+  name     = "redis"
+  type     = "CNAME"
+  zone_id  = data.aws_route53_zone.environment_cert.id
+  records  = [aws_elasticache_replication_group.lpa_redis.primary_endpoint_address]
+  ttl      = 300
+  provider = aws.management
+}

--- a/terraform/environment/elasticache.tf
+++ b/terraform/environment/elasticache.tf
@@ -1,0 +1,71 @@
+resource "aws_elasticache_replication_group" "lpa_redis" {
+  automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
+  engine                        = "redis"
+  engine_version                = "5.0.6"
+  replication_group_id          = "lpa-data-redis-${local.environment}"
+  replication_group_description = "Replication Group for LPA Data"
+  node_type                     = "cache.t2.small"
+  number_cache_clusters         = local.account.elasticache_count
+  parameter_group_name          = "default.redis5.0"
+  port                          = 6379
+  subnet_group_name             = "private-redis"
+  security_group_ids            = [aws_security_group.lpa_redis_sg.id]
+  tags                          = local.default_tags
+  apply_immediately             = true
+
+  lifecycle {
+    ignore_changes = [number_cache_clusters]
+  }
+}
+
+resource "aws_security_group" "lpa_redis_sg" {
+  name_prefix = "${local.environment}-redis-sg"
+  vpc_id      = local.account.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  revoke_rules_on_delete = true
+
+  tags = merge(
+    local.default_tags,
+    {
+      "Name" = "${local.environment}-redis-sg"
+    },
+  )
+}
+
+locals {
+  redis_rules = {
+    cache_out = {
+      port        = 6379
+      type        = "egress"
+      protocol    = "tcp"
+      target_type = "self"
+      target      = true
+    }
+    cache_in = {
+      port        = 6379
+      type        = "ingress"
+      protocol    = "tcp"
+      target_type = "self"
+      target      = true
+    }
+  }
+}
+
+resource "aws_security_group_rule" "lpa_redis_rules" {
+  for_each = local.redis_rules
+
+  type                     = each.value.type
+  protocol                 = each.value.protocol
+  from_port                = each.value.port
+  to_port                  = each.value.port
+  security_group_id        = aws_security_group.lpa_redis_sg.id
+  source_security_group_id = each.value.target_type == "security_group_id" ? each.value.target : null
+  prefix_list_ids          = each.value.target_type == "prefix_list_id" ? [each.value.target] : null
+  description              = each.key
+  cidr_blocks              = each.value.target_type == "cidr_block" ? [each.value.target] : null
+  self                     = each.value.target_type == "self" ? each.value.target : null
+}

--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -9,6 +9,7 @@ module "lambda_lpa_v1" {
   openapi_version        = "v1"
   rest_api               = aws_api_gateway_rest_api.lpa
   account                = local.account
+  redis_sg_id            = aws_security_group.lpa_redis_sg.id
 }
 
 //Modify here for new version - create new one. keep original

--- a/terraform/environment/modules/lambda/lambda.tf
+++ b/terraform/environment/modules/lambda/lambda.tf
@@ -18,8 +18,11 @@ resource "aws_lambda_function" "lambda_function" {
   depends_on       = [aws_cloudwatch_log_group.lambda]
   layers           = [aws_lambda_layer_version.lambda_layer.arn]
   vpc_config {
-    subnet_ids         = var.aws_subnet_ids
-    security_group_ids = [data.aws_security_group.lambda_api_ingress.id]
+    subnet_ids = var.aws_subnet_ids
+    security_group_ids = [
+      data.aws_security_group.lambda_api_ingress.id,
+      var.redis_sg_id
+    ]
   }
   environment {
     variables = {
@@ -49,7 +52,7 @@ resource "aws_lambda_permission" "lambda_permission" {
 resource "aws_lambda_layer_version" "lambda_layer" {
   filename         = data.archive_file.lambda_layer_archive.output_path
   source_code_hash = data.archive_file.lambda_layer_archive.output_base64sha256
-  layer_name       = "requirement_${var.account.target_environment}"
+  layer_name       = "lpa_requirements_${var.account.target_environment}"
 
   compatible_runtimes = ["python3.7"]
 

--- a/terraform/environment/modules/lambda/variables.tf
+++ b/terraform/environment/modules/lambda/variables.tf
@@ -25,3 +25,5 @@ variable "openapi_version" {}
 variable "rest_api" {}
 
 variable "account" {}
+
+variable "redis_sg_id" {}

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -14,7 +14,8 @@
       "target_environment": "dev",
       "vpc_id": "vpc-faf2d99e",
       "logger_level": "DEBUG",
-      "threshold": 10
+      "threshold": 10,
+      "elasticache_count": 1
     },
     "preproduction": {
       "account_id": "492687888235",
@@ -29,7 +30,8 @@
       "target_environment": "preproduction",
       "vpc_id": "vpc-037acd53d9ce813b4",
       "logger_level": "INFO",
-      "threshold": 10
+      "threshold": 10,
+      "elasticache_count": 1
     },
     "production": {
       "account_id": "649098267436",
@@ -44,7 +46,8 @@
       "target_environment": "production",
       "vpc_id": "vpc-6809cc0f",
       "logger_level": "INFO",
-      "threshold": 1
+      "threshold": 1,
+      "elasticache_count": 2
     }
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -19,6 +19,7 @@ variable "accounts" {
       session_data       = string
       target_environment = string
       threshold          = number
+      elasticache_count  = number
     })
   )
 }


### PR DESCRIPTION
## Purpose

So that we can perform cacheing functions using redis, we need the infra in place to do so.

## Approach

Added an elasticache cluster with failover in prod and single node in other envs

## Learning

Search for hello world redis with python for simple script that can be easily modified to test the config! 

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
