### PR TITLE
IN-318 config object

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-08-04T13:24:40Z",
+  "generated_at": "2020-08-06T13:38:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -58,7 +58,7 @@
       {
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 60,
+        "line_number": 64,
         "type": "Secret Keyword"
       }
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "4584:4584"
+  redis:
+    image: "redis:alpine"
+    ports:
+     - "0.0.0.0:6379:6379"
   api_gateway:
     build:
       context: ./lambda_functions/v1
@@ -65,6 +69,10 @@ services:
       SIRIUS_API_VERSION: v1
       SESSION_DATA: publicapi@opgtest.com
       LOCALSTACK_HOST: motoserver
+      REQUEST_CACHING: enabled
+      REQUEST_CACHING_TTL: 48
+      REQUEST_CACHING_NAME: opg-data-lpa
+      REDIS_URL: redis://redis:6379
     networks:
       default:
         aliases:

--- a/integration_tests/v1/conftest.py
+++ b/integration_tests/v1/conftest.py
@@ -11,13 +11,13 @@ from requests_aws4auth import AWS4Auth
 opg_sirius_api_gateway_dev_aws = {
     "name": "original collections api on aws dev",
     "online_tool_endpoint": {
-        "url": "https://api.dev.sirius.opg.digital/v1/lpa-online-tool/lpas",
+        "url": "https://3d9iqi6bq9.execute-api.eu-west-1.amazonaws.com/v1/lpa-online-tool/lpas",
         "method": "GET",
         "valid_lpa_online_tool_ids": ["A33718377316"],
         "invalid_lpa_online_tool_ids": ["banana"],
     },
     "use_an_lpa_endpoint": {
-        "url": "https://api.dev.sirius.opg.digital/v1/use-an-lpa/lpas",
+        "url": "https://3d9iqi6bq9.execute-api.eu-west-1.amazonaws.com/v1/use-an-lpa/lpas",
         "method": "GET",
         "valid_sirius_uids": ["700000000013"],
         "invalid_sirius_uids": ["9"],
@@ -27,14 +27,41 @@ opg_sirius_api_gateway_dev_aws = {
 
 opg_data_lpa_dev_aws = {
     "name": "new collections api on aws dev",
+    "healthcheck_endpoint": {
+        "url": "https://in318configobj.dev.lpa.api.opg.service.justice.gov.uk/v1/healthcheck",
+        "method": "GET",
+    },
     "online_tool_endpoint": {
-        "url": "https://dev.lpa.api.opg.service.justice.gov.uk/v1/lpa-online-tool/lpas",
+        "url": "https://in318configobj.dev.lpa.api.opg.service.justice.gov.uk/v1/lpa"
+        "-online-tool/lpas",
         "method": "GET",
         "valid_lpa_online_tool_ids": ["A33718377316"],
         "invalid_lpa_online_tool_ids": ["banana"],
     },
     "use_an_lpa_endpoint": {
-        "url": "https://dev.lpa.api.opg.service.justice.gov.uk/v1/use-an-lpa/lpas",
+        "url": "https://in318configobj.dev.lpa.api.opg.service.justice.gov.uk/v1/use"
+        "-an-lpa/lpas",
+        "method": "GET",
+        "valid_sirius_uids": ["700000000013"],
+        "invalid_sirius_uids": ["9"],
+    },
+}
+
+
+opg_data_lpa_local_mock = {
+    "name": "new collections api local mock",
+    "healthcheck_endpoint": {
+        "url": "http://0.0.0.0:4343/v1/healthcheck",
+        "method": "GET",
+    },
+    "online_tool_endpoint": {
+        "url": "http://0.0.0.0:4343/v1/lpa-online-tool/lpas",
+        "method": "GET",
+        "valid_lpa_online_tool_ids": ["A33718377316"],
+        "invalid_lpa_online_tool_ids": ["banana"],
+    },
+    "use_an_lpa_endpoint": {
+        "url": "http://0.0.0.0:4343/v1/use-an-lpa/lpas",
         "method": "GET",
         "valid_sirius_uids": ["700000000013"],
         "invalid_sirius_uids": ["9"],

--- a/integration_tests/v1/response_schemas/use_an_lpa_schema.json
+++ b/integration_tests/v1/response_schemas/use_an_lpa_schema.json
@@ -131,7 +131,7 @@
       "type": "boolean"
     },
     "onlineLpaId": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "cancellationDate": {
       "type": "null"

--- a/integration_tests/v1/test_healthcheck.py
+++ b/integration_tests/v1/test_healthcheck.py
@@ -1,0 +1,16 @@
+import pytest
+import json
+from .conftest import send_a_request, configs_to_test, is_valid_schema
+
+
+@pytest.mark.smoke_test
+@pytest.mark.parametrize("test_config", configs_to_test)
+def test_healthcheck_route(test_config):
+
+    status, response = send_a_request(
+        test_config=test_config,
+        url=f"{test_config['healthcheck_endpoint']['url']}",
+        method=test_config["healthcheck_endpoint"]["method"],
+    )
+
+    assert status == 200

--- a/lambda_functions/v1/functions/lpa/app/__init__.py
+++ b/lambda_functions/v1/functions/lpa/app/__init__.py
@@ -1,12 +1,17 @@
+from flask import Flask
+
 from .api.resources import api as api_blueprint
+from .api.sirius_service import SiriusService
+from .config import Config
 
 
-def create_app(Flask):
+def create_app(config=Config):
     app = Flask(__name__)
+
+    app.config.from_object(config)
 
     app.register_blueprint(api_blueprint)
 
-    routes = [str(p) for p in app.url_map.iter_rules()]
-    print(f"routes: {routes}")
+    app.sirius = SiriusService(config_params=config)
 
     return app

--- a/lambda_functions/v1/functions/lpa/app/__init__.py
+++ b/lambda_functions/v1/functions/lpa/app/__init__.py
@@ -1,4 +1,6 @@
+import redis
 from flask import Flask
+
 
 from .api.resources import api as api_blueprint
 from .api.sirius_service import SiriusService
@@ -12,6 +14,10 @@ def create_app(config=Config):
 
     app.register_blueprint(api_blueprint)
 
-    app.sirius = SiriusService(config_params=config)
+    app.redis = redis.StrictRedis.from_url(
+        url=config.REDIS_URL, charset="utf-8", decode_responses=True
+    )
+
+    app.sirius = SiriusService(config_params=config, cache=app.redis)
 
     return app

--- a/lambda_functions/v1/functions/lpa/app/__init__.py
+++ b/lambda_functions/v1/functions/lpa/app/__init__.py
@@ -7,8 +7,8 @@ from .api.sirius_service import SiriusService
 from .config import Config
 
 
-def create_app(config=Config):
-    app = Flask(__name__)
+def create_app(flask=Flask, config=Config):
+    app = flask(__name__)
 
     app.config.from_object(config)
 
@@ -18,6 +18,8 @@ def create_app(config=Config):
         url=config.REDIS_URL, charset="utf-8", decode_responses=True
     )
 
-    app.sirius = SiriusService(config_params=config, cache=app.redis)
+    redis_cache = app.redis
+
+    app.sirius = SiriusService(config_params=config, cache=redis_cache)
 
     return app

--- a/lambda_functions/v1/functions/lpa/app/__init__.py
+++ b/lambda_functions/v1/functions/lpa/app/__init__.py
@@ -14,11 +14,15 @@ def create_app(flask=Flask, config=Config):
 
     app.register_blueprint(api_blueprint)
 
-    app.redis = redis.StrictRedis.from_url(
-        url=config.REDIS_URL, charset="utf-8", decode_responses=True
-    )
+    if config.REQUEST_CACHING == "enabled":
+        app.redis = redis.StrictRedis.from_url(
+            url=config.REDIS_URL, charset="utf-8", decode_responses=True
+        )
 
-    redis_cache = app.redis
+        redis_cache = app.redis
+
+    else:
+        redis_cache = None
 
     app.sirius = SiriusService(config_params=config, cache=redis_cache)
 

--- a/lambda_functions/v1/functions/lpa/app/api/handlers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/handlers.py
@@ -43,7 +43,7 @@ def get_by_sirius_uid(sirius_uid):
     sirius_url = generate_sirius_url(sirius_uid=sirius_uid)
 
     sirius_status_code, sirius_response = current_app.sirius.send_request_to_sirius(
-        url=sirius_url, method="GET"
+        key=sirius_url, url=sirius_url, method="GET"
     )
     if sirius_status_code in [200]:
         if len(sirius_response) > 0:

--- a/lambda_functions/v1/functions/lpa/app/api/handlers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/handlers.py
@@ -2,12 +2,16 @@ import json
 import os
 
 import urllib3
+
+# from flask import current_app
+from flask import current_app
 from werkzeug.exceptions import abort
 
 from .helpers import custom_logger
 
-# from .sirius_service import build_sirius_url, send_request_to_sirius
-from . import sirius_service
+# from .sirius import build_sirius_url, send_request_to_sirius
+# from . import sirius
+from .sirius_service import SiriusService
 
 logger = custom_logger()
 
@@ -16,7 +20,7 @@ def get_by_online_tool_id(lpa_online_tool_id):
 
     sirius_url = generate_sirius_url(lpa_online_tool_id=lpa_online_tool_id)
 
-    sirius_status_code, sirius_response = sirius_service.send_request_to_sirius(
+    sirius_status_code, sirius_response = current_app.sirius.send_request_to_sirius(
         key=lpa_online_tool_id, url=sirius_url, method="GET"
     )
 
@@ -38,7 +42,7 @@ def get_by_online_tool_id(lpa_online_tool_id):
 def get_by_sirius_uid(sirius_uid):
     sirius_url = generate_sirius_url(sirius_uid=sirius_uid)
 
-    sirius_status_code, sirius_response = sirius_service.send_request_to_sirius(
+    sirius_status_code, sirius_response = current_app.sirius.send_request_to_sirius(
         url=sirius_url, method="GET"
     )
     if sirius_status_code in [200]:
@@ -57,14 +61,16 @@ def get_by_sirius_uid(sirius_uid):
 
 
 def generate_sirius_url(lpa_online_tool_id=None, sirius_uid=None):
-    sirius_api_version = os.environ["SIRIUS_API_VERSION"]
+    sirius_api_version = "v1"
     sirius_api_url = f"api/public/{sirius_api_version}/lpas"
     if lpa_online_tool_id:
         sirius_url_params = {"lpa-online-tool-id": lpa_online_tool_id}
     elif sirius_uid:
         sirius_url_params = {"uid": sirius_uid}
 
-    url = sirius_service.build_sirius_url(
+    logger.info(f"sirius_api_url: {sirius_api_url}")
+
+    url = current_app.sirius.build_sirius_url(
         endpoint=sirius_api_url, url_params=sirius_url_params,
     )
 

--- a/lambda_functions/v1/functions/lpa/app/api/handlers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/handlers.py
@@ -13,14 +13,12 @@ logger = custom_logger()
 
 
 def get_by_online_tool_id(lpa_online_tool_id):
+
     sirius_url = generate_sirius_url(lpa_online_tool_id=lpa_online_tool_id)
 
     sirius_status_code, sirius_response = sirius_service.send_request_to_sirius(
-        url=sirius_url, method="GET"
+        key=lpa_online_tool_id, url=sirius_url, method="GET"
     )
-
-    logger.info(f"sirius_status_code: {sirius_status_code}")
-    logger.info(f"sirius_response: {sirius_response}")
 
     if sirius_status_code in [200]:
         if len(sirius_response) > 0:

--- a/lambda_functions/v1/functions/lpa/app/api/helpers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/helpers.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+# from flask import current_app
+
 
 def custom_logger(name=None):
     """
@@ -25,6 +27,7 @@ def custom_logger(name=None):
 
     try:
         logger.setLevel(os.environ["LOGGER_LEVEL"])
+        # logger.setLevel(current_app.config['LOGGER_LEVEL'])
     except KeyError:
         logger.setLevel("INFO")
     logger.addHandler(handler)

--- a/lambda_functions/v1/functions/lpa/app/api/resources.py
+++ b/lambda_functions/v1/functions/lpa/app/api/resources.py
@@ -7,6 +7,7 @@ from .errors import error_message
 from .handlers import get_by_online_tool_id, get_by_sirius_uid
 from .helpers import custom_logger
 
+
 logger = custom_logger("")
 
 version = "v1"
@@ -60,6 +61,11 @@ def handle504(error=None):
 @api.route("/healthcheck", methods=["HEAD", "GET"])
 def handle_healthcheck_route():
     response_message = "OK"
+
+    from flask import current_app
+
+    logger.info(f"current_app: {current_app}")
+    logger.info(f"current_app.config: {current_app.config}")
 
     return jsonify(response_message), 200
 

--- a/lambda_functions/v1/functions/lpa/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/lpa/app/api/sirius_service.py
@@ -9,244 +9,242 @@ import localstack_client.session
 import requests
 from botocore.exceptions import ClientError
 
+
 from .helpers import custom_logger
 import redis
 
 logger = custom_logger("sirius_service")
 
 
-def build_sirius_url(endpoint, url_params=None):
-    """
-    Builds the url for the endpoint from variables (probably saved in env vars)
+class SiriusService:
+    def __init__(self, config_params):
 
-    Args:
-        base_url: URL of the Sirius server
-        api_route: path to public api
-        endpoint: endpoint
-    Returns:
-        string: url
-    """
+        try:
+            self.sirius_base_url = config_params.SIRIUS_BASE_URL
+            self.environment = config_params.ENVIRONMENT
+            self.session_data = config_params.SESSION_DATA
+            self.redis_url = config_params.REDIS_URL
+            self.request_caching = config_params.REQUEST_CACHING
+            self.request_caching_name = config_params.REQUEST_CACHE_NAME
+            self.request_caching_ttl = config_params.REQUEST_CACHING_TTL
+        except Exception as e:
+            logger.info(f"Error loading config e: {e}")
 
-    try:
-        base_url = os.environ["SIRIUS_BASE_URL"]
-    except KeyError as e:
-        logger.error(f"Unable to build Sirius URL {e}")
-        raise Exception
+    def build_sirius_url(self, endpoint, url_params=None):
+        """
+        Builds the url for the endpoint from variables (probably saved in env vars)
 
-    sirius_url = f"{base_url}/{quote(endpoint)}"
+        Args:
+            base_url: URL of the Sirius server
+            api_route: path to public api
+            endpoint: endpoint
+        Returns:
+            string: url
+        """
 
-    if url_params:
-        encoded_params = urlencode(url_params)
-        url = f"{sirius_url}?{encoded_params}"
-    else:
-        url = sirius_url
+        try:
+            base_url = self.sirius_base_url
+        except KeyError as e:
+            logger.error(f"Unable to build Sirius URL {e}")
+            raise Exception
 
-    return url
+        sirius_url = f"{base_url}/{quote(endpoint)}"
 
+        if url_params:
+            encoded_params = urlencode(url_params)
+            url = f"{sirius_url}?{encoded_params}"
+        else:
+            url = sirius_url
 
-def get_secret(environment):
-    """
-    Gets and decrypts the JWT secret from AWS Secrets Manager for the chosen environment
-    This was c&p directly from AWS Secrets Manager...
+        return url
 
-    Args:
-        environment: AWS environment name
-    Returns:
-        JWT secret
-    Raises:
-        ClientError
-    """
+    def _get_secret(self):
+        """
+        Gets and decrypts the JWT secret from AWS Secrets Manager for the chosen environment
+        This was c&p directly from AWS Secrets Manager...
 
-    secret_name = f"{environment}/jwt-key"
-    region_name = "eu-west-1"
+        Args:
+            environment: AWS environment name
+        Returns:
+            JWT secret
+        Raises:
+            ClientError
+        """
 
-    if environment == "local":
-        logger.info("Using local AWS Secrets Manager")
-        current_session = localstack_client.session.Session()
+        environment = self.environment
+        secret_name = f"{environment}/jwt-key"
+        region_name = "eu-west-1"
 
-    else:
-        current_session = boto3.session.Session()
+        if environment == "local":
+            logger.info("Using local AWS Secrets Manager")
+            current_session = localstack_client.session.Session()
 
-    client = current_session.client(
-        service_name="secretsmanager", region_name=region_name
-    )
+        else:
+            current_session = boto3.session.Session()
 
-    try:
-        get_secret_value_response = client.get_secret_value(SecretId=secret_name)
-        secret = get_secret_value_response["SecretString"]
-    except ClientError as e:
-        logger.info(f"Unable to get secret from Secrets Manager {e}")
-        raise e
-
-    return secret
-
-
-def build_sirius_headers(content_type="application/json"):
-    """
-    Builds headers for Sirius request, including JWT auth
-
-    Args:
-        content_type: string, defaults to 'application/json'
-    Returns:
-        Header dictionary with content type and auth token
-    """
-
-    if not content_type:
-        content_type = "application/json"
-
-    environment = os.environ["ENVIRONMENT"]
-    session_data = os.environ["SESSION_DATA"]
-
-    encoded_jwt = jwt.encode(
-        {
-            "session-data": session_data,
-            "iat": datetime.datetime.utcnow(),
-            "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
-        },
-        get_secret(environment),
-        algorithm="HS256",
-    )
-
-    return {
-        "Content-Type": content_type,
-        "Authorization": "Bearer " + encoded_jwt.decode("UTF8"),
-    }
-
-
-def handle_sirius_error(error_code=None, error_message=None, error_details=None):
-    error_code = error_code if error_code else 500
-    error_message = (
-        error_message if error_message else "Unknown error talking to " "Sirius"
-    )
-
-    try:
-        error_details = error_details["detail"]
-
-    except (KeyError, TypeError):
-        error_details = str(error_details) if len(str(error_details)) > 0 else "None"
-
-    message = f"{error_message}, details: {str(error_details)}"
-    logger.error(message)
-    return error_code, message
-
-
-def check_sirius_available():
-    healthcheck_url = f'{os.environ["SIRIUS_BASE_URL"]}/health-check'
-    r = requests.get(url=healthcheck_url)
-
-    return True if r.status_code == 200 else False
-
-
-def send_request_to_sirius(key, url, method, content_type=None, data=None):
-
-    try:
-        cache_enabled = True if os.environ["REQUEST_CACHING"] == "enabled" else False
-    except KeyError:
-        cache_enabled = False
-
-    if check_sirius_available():
-        sirius_status_code, sirius_data = get_data_from_sirius(
-            url, method, content_type, data
+        client = current_session.client(
+            service_name="secretsmanager", region_name=region_name
         )
-        if cache_enabled and method == "GET" and sirius_status_code == 200:
-            logger.info(f"Putting data in cache with key: {key}")
-            put_sirius_data_in_cache(
-                redis_conn=get_redis_client(), key=key, data=sirius_data
+
+        try:
+            get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+            secret = get_secret_value_response["SecretString"]
+        except ClientError as e:
+            logger.info(f"Unable to get secret from Secrets Manager {e}")
+            raise e
+
+        return secret
+
+    def _build_sirius_headers(self, content_type="application/json"):
+        """
+        Builds headers for Sirius request, including JWT auth
+
+        Args:
+            content_type: string, defaults to 'application/json'
+        Returns:
+            Header dictionary with content type and auth token
+        """
+
+        if not content_type:
+            content_type = "application/json"
+
+        session_data = self.session_data
+
+        encoded_jwt = jwt.encode(
+            {
+                "session-data": session_data,
+                "iat": datetime.datetime.utcnow(),
+                "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
+            },
+            self._get_secret(),
+            algorithm="HS256",
+        )
+
+        return {
+            "Content-Type": content_type,
+            "Authorization": "Bearer " + encoded_jwt.decode("UTF8"),
+        }
+
+    def _handle_sirius_error(
+        self, error_code=None, error_message=None, error_details=None
+    ):
+        error_code = error_code if error_code else 500
+        error_message = (
+            error_message if error_message else "Unknown error talking to " "Sirius"
+        )
+
+        try:
+            error_details = error_details["detail"]
+
+        except (KeyError, TypeError):
+            error_details = (
+                str(error_details) if len(str(error_details)) > 0 else "None"
             )
 
-        return sirius_status_code, sirius_data
-    else:
-        if cache_enabled and method == "GET":
-            logger.info(f"Getting data from cache with key: {key}")
-            sirius_status_code, sirius_data = get_sirius_data_from_cache(
-                redis_conn=get_redis_client(), key=key
+        message = f"{error_message}, details: {str(error_details)}"
+        logger.error(message)
+        return error_code, message
+
+    def _check_sirius_available(self):
+        # healthcheck_url = f"{self.sirius_base_url}/health-check"
+        # r = requests.get(url=healthcheck_url)
+
+        # return True if r.status_code == 200 else False
+        return True
+
+    def send_request_to_sirius(self, key, url, method, content_type=None, data=None):
+
+        try:
+            cache_enabled = True if self.request_caching == "enabled" else False
+        except KeyError:
+            cache_enabled = False
+
+        if self._check_sirius_available():
+            sirius_status_code, sirius_data = self._get_data_from_sirius(
+                url, method, content_type, data
             )
+            if cache_enabled and method == "GET" and sirius_status_code == 200:
+                logger.info(f"Putting data in cache with key: {key}")
+                self._put_sirius_data_in_cache(
+                    redis_conn=self._get_redis_client(), key=key, data=sirius_data
+                )
 
             return sirius_status_code, sirius_data
         else:
-            return handle_sirius_error(
-                error_message=f"Unable to send request to Sirius",
-                error_details=f"Sirius not available",
+            if cache_enabled and method == "GET":
+                logger.info(f"Getting data from cache with key: {key}")
+                sirius_status_code, sirius_data = self._get_sirius_data_from_cache(
+                    redis_conn=self._get_redis_client(), key=key
+                )
+
+                return sirius_status_code, sirius_data
+            else:
+                return self._handle_sirius_error(
+                    error_message=f"Unable to send request to Sirius",
+                    error_details=f"Sirius not available",
+                )
+
+    def _get_data_from_sirius(self, url, method, content_type=None, data=None):
+
+        headers = self._build_sirius_headers(content_type)
+
+        try:
+            if method == "PUT":
+                r = requests.put(url=url, data=data, headers=headers)
+                return r.status_code, r.json()
+
+            elif method == "POST":
+                r = requests.post(url=url, data=data, headers=headers)
+                return r.status_code, r.json()
+            elif method == "GET":
+                r = requests.get(url=url, headers=headers)
+
+                return r.status_code, r.json()
+            else:
+                return self._handle_sirius_error(
+                    error_message=f"Unable to send request to Sirius",
+                    error_details=f"Method {method} not allowed on Sirius route",
+                )
+
+        except Exception as e:
+            return self._handle_sirius_error(
+                error_message=f"Unable to send request to Sirius", error_details=e
             )
 
+    def _get_redis_client(self):
+        redis_url = self.redis_url
 
-def get_data_from_sirius(url, method, content_type=None, data=None):
-
-    headers = build_sirius_headers(content_type)
-
-    try:
-        if method == "PUT":
-            r = requests.put(url=url, data=data, headers=headers)
-            return r.status_code, r.json()
-
-        elif method == "POST":
-            r = requests.post(url=url, data=data, headers=headers)
-            return r.status_code, r.json()
-        elif method == "GET":
-            r = requests.get(url=url, headers=headers)
-
-            return r.status_code, r.json()
-        else:
-            return handle_sirius_error(
-                error_message=f"Unable to send request to Sirius",
-                error_details=f"Method {method} not allowed on Sirius route",
-            )
-
-    except Exception as e:
-        return handle_sirius_error(
-            error_message=f"Unable to send request to Sirius", error_details=e
+        r = redis.StrictRedis.from_url(
+            url=redis_url, charset="utf-8", decode_responses=True
         )
 
+        return r
 
-def get_redis_client():
-    redis_url = os.environ["REDIS_URL"]
+    def _put_sirius_data_in_cache(self, redis_conn, key, data):
+        cache_name = self.request_caching_name
+        cache_ttl_in_seconds = self.request_caching_ttl * 60 * 60
 
-    r = redis.StrictRedis.from_url(
-        url=redis_url, charset="utf-8", decode_responses=True
-    )
+        data = json.dumps(data)
 
-    return r
+        redis_conn.set(name=f"{cache_name}-{key}", value=data, ex=cache_ttl_in_seconds)
 
+        logger.info(f"setting redis: {cache_name}-{key}")
 
-def put_sirius_data_in_cache(redis_conn, key, data):
+    def _get_sirius_data_from_cache(self, redis_conn, key):
 
-    try:
-        cache_ttl = int(os.environ["REQUEST_CACHING_TTL"])
-    except KeyError:
-        cache_ttl = 48
+        cache_name = self.request_caching_name
 
-    try:
-        cache_name = os.environ["REQUEST_CACHING_NAME"]
-    except KeyError:
-        cache_name = "default_sirius_cache"
+        logger.info(f"getting redis: {cache_name}-{key}")
+        logger.info(
+            f'redis_conn.exists(f"{cache_name}-{key}"): {redis_conn.exists(f"{cache_name}-{key}")}'
+        )
 
-    cache_ttl_in_seconds = cache_ttl * 60 * 60
+        if redis_conn.exists(f"{cache_name}-{key}"):
+            status_code = 200
+            result = redis_conn.get(f"{cache_name}-{key}")
+            result = json.loads(result)
+        else:
+            status_code = 500
+            result = None
 
-    data = json.dumps(data)
-
-    redis_conn.set(name=f"{cache_name}-{key}", value=data, ex=cache_ttl_in_seconds)
-
-    logger.info(f"setting redis: {cache_name}-{key}")
-
-
-def get_sirius_data_from_cache(redis_conn, key):
-
-    try:
-        cache_name = os.environ["REQUEST_CACHING_NAME"]
-    except KeyError:
-        cache_name = "default_sirius_cache"
-
-    logger.info(f"getting redis: {cache_name}-{key}")
-    logger.info(
-        f'redis_conn.exists(f"{cache_name}-{key}"): {redis_conn.exists(f"{cache_name}-{key}")}'
-    )
-
-    if redis_conn.exists(f"{cache_name}-{key}"):
-        status_code = 200
-        result = redis_conn.get(f"{cache_name}-{key}")
-        result = json.loads(result)
-    else:
-        status_code = 500
-        result = None
-
-    return status_code, result
+        return status_code, result

--- a/lambda_functions/v1/functions/lpa/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/lpa/app/api/sirius_service.py
@@ -1,18 +1,24 @@
 import datetime
+import json
 import os
-from urllib.parse import urlparse, urlencode, quote
+from urllib.parse import urlencode, quote
 
 import boto3
 import jwt
 import localstack_client.session
-
 import requests
 from botocore.exceptions import ClientError
 
-
 from .helpers import custom_logger
+import redis
 
 logger = custom_logger("sirius_service")
+
+redis_url = os.environ["REDIS_URL"]
+
+redis = redis.StrictRedis.from_url(
+    url=redis_url, charset="utf-8", decode_responses=True
+)
 
 
 def build_sirius_url(endpoint, url_params=None):
@@ -60,13 +66,11 @@ def get_secret(environment):
     secret_name = f"{environment}/jwt-key"
     region_name = "eu-west-1"
 
-    try:
-        if os.environ["ENVIRONMENT"] == "local":
-            current_session = localstack_client.session.Session()
+    if environment == "local":
+        logger.info("Using local AWS Secrets Manager")
+        current_session = localstack_client.session.Session()
 
-        else:
-            current_session = boto3.session.Session()
-    except KeyError:
+    else:
         current_session = boto3.session.Session()
 
     client = current_session.client(
@@ -132,7 +136,44 @@ def handle_sirius_error(error_code=None, error_message=None, error_details=None)
     return error_code, message
 
 
-def send_request_to_sirius(url, method, content_type=None, data=None):
+def check_sirius_available():
+    healthcheck_url = f'{os.environ["SIRIUS_BASE_URL"]}/health-check'
+    r = requests.get(url=healthcheck_url)
+    print(f"r: {r}")
+
+    # return True if r.status_code == 200 else False
+    return False
+
+
+def send_request_to_sirius(key, url, method, content_type=None, data=None):
+
+    try:
+        cache_enabled = True if os.environ["REQUEST_CACHING"] == "enabled" else False
+    except KeyError:
+        cache_enabled = False
+
+    if check_sirius_available():
+        sirius_status_code, sirius_data = get_data_from_sirius(
+            url, method, content_type, data
+        )
+        if cache_enabled and method == "GET" and sirius_status_code == 200:
+            put_sirius_data_in_cache(key, sirius_data)
+
+        return sirius_status_code, sirius_data
+    else:
+        if cache_enabled:
+            sirius_status_code = 200
+            sirius_data = get_sirius_data_from_cache(key)
+
+            return sirius_status_code, sirius_data
+        else:
+            return handle_sirius_error(
+                error_message=f"Unable to send request to Sirius",
+                error_details=f"Sirius not available",
+            )
+
+
+def get_data_from_sirius(url, method, content_type=None, data=None):
 
     headers = build_sirius_headers(content_type)
 
@@ -146,6 +187,9 @@ def send_request_to_sirius(url, method, content_type=None, data=None):
             return r.status_code, r.json()
         elif method == "GET":
             r = requests.get(url=url, headers=headers)
+
+            # get_data_from_cache(key=key, data=json.dumps(r.json()))
+
             return r.status_code, r.json()
         else:
             return handle_sirius_error(
@@ -157,3 +201,28 @@ def send_request_to_sirius(url, method, content_type=None, data=None):
         return handle_sirius_error(
             error_message=f"Unable to send request to Sirius", error_details=e
         )
+
+
+def put_sirius_data_in_cache(key, data=None):
+    cache_name = os.environ["REQUEST_CACHING_NAME"]
+
+    data = json.dumps(data)
+
+    redis.mset({f"{cache_name}-{key}": data})
+
+    logger.info(f"setting redis: {cache_name}-{key}")
+
+
+def get_sirius_data_from_cache(key):
+
+    cache_name = os.environ["REQUEST_CACHING_NAME"]
+
+    logger.info(f"getting redis: {cache_name}-{key}")
+
+    if redis.exists(f"{cache_name}-{key}"):
+        result = redis.mget(f"{cache_name}-{key}")
+        result = json.loads(result[0])
+    else:
+        result = None
+
+    return result

--- a/lambda_functions/v1/functions/lpa/app/config.py
+++ b/lambda_functions/v1/functions/lpa/app/config.py
@@ -17,8 +17,12 @@ class Config(object):
     REQUEST_CACHE_NAME = API_NAME
     REQUEST_CACHING_TTL = 48
 
-    REQUEST_CACHING = os.environ.get("REQUEST_CACHING", default="disabled")
     REDIS_URL = os.environ.get("REDIS_URL")
+    REQUEST_CACHING = os.environ.get("REQUEST_CACHING", default="disabled")
+
+
+class ProductionConfig(Config):
+    pass
 
 
 class LocalMockConfig(Config):

--- a/lambda_functions/v1/functions/lpa/app/config.py
+++ b/lambda_functions/v1/functions/lpa/app/config.py
@@ -1,0 +1,56 @@
+import os
+
+
+class Config(object):
+    DEBUG = False
+    TESTING = False
+    LOGGER_LEVEL = "INFO"
+    API_VERSION = "v1"
+    API_NAME = "opg-data-lpa"
+    ENVIRONMENT = os.environ.get("ENVIRONMENT")
+
+    # sirius
+    SIRIUS_BASE_URL = os.environ.get("SIRIUS_BASE_URL")
+    SESSION_DATA = os.environ.get("SESSION_DATA")
+
+    # caching
+    REQUEST_CACHE_NAME = API_NAME
+    REQUEST_CACHING_TTL = 48
+
+    REQUEST_CACHING = os.environ.get("REQUEST_CACHING", default="disabled")
+    REDIS_URL = os.environ.get("REDIS_URL")
+
+
+class LocalMockConfig(Config):
+    # override prod values
+    DEBUG = True
+    TESTING = True
+    LOGGER_LEVEL = "DEBUG"
+
+    REQUEST_CACHING = "enabled"
+    REQUEST_CACHE_NAME = "opg-data-lpa-local"
+
+    # specific to local testing
+    HYPOTHESIS_MAX_EXAMPLES = 50
+    LOCALSTACK_HOST = "motoserver"
+    JWT_SECRET = "THIS_IS_MY_SECRET_KEY"  # pragma: allowlist secret
+
+
+class LocalTestingConfig(Config):
+    # override prod values
+    DEBUG = True
+    TESTING = True
+    LOGGER_LEVEL = "DEBUG"
+
+    SIRIUS_BASE_URL = "http://not-really-sirius.com"
+    SESSION_DATA = "publicapi@opgtest.com"
+
+    REQUEST_CACHING = "enabled"
+    REQUEST_CACHING_TTL = 48
+    REQUEST_CACHE_NAME = "opg-data-lpa-local"
+    REDIS_URL = "redis://redis:6379"
+
+    # specific to local testing
+    HYPOTHESIS_MAX_EXAMPLES = 50
+    LOCALSTACK_HOST = "motoserver"
+    JWT_SECRET = "THIS_IS_MY_SECRET_KEY"  # pragma: allowlist secret

--- a/lambda_functions/v1/functions/lpa/app/lpa.py
+++ b/lambda_functions/v1/functions/lpa/app/lpa.py
@@ -1,5 +1,5 @@
 from .flask_lambda import FlaskLambda
 from . import create_app
+from .config import ProductionConfig
 
-
-lambda_handler = create_app(FlaskLambda)
+lambda_handler = create_app(flask=FlaskLambda, config=ProductionConfig)

--- a/lambda_functions/v1/functions/lpa/app/lpa_local.py
+++ b/lambda_functions/v1/functions/lpa/app/lpa_local.py
@@ -1,4 +1,6 @@
 from . import create_app
 from flask import Flask
 
-lambda_handler = create_app(Flask)
+from .config import LocalMockConfig
+
+lambda_handler = create_app(config=LocalMockConfig)

--- a/lambda_functions/v1/functions/lpa/app/lpa_local.py
+++ b/lambda_functions/v1/functions/lpa/app/lpa_local.py
@@ -3,4 +3,4 @@ from flask import Flask
 
 from .config import LocalMockConfig
 
-lambda_handler = create_app(config=LocalMockConfig)
+lambda_handler = create_app(flask=Flask, config=LocalMockConfig)

--- a/lambda_functions/v1/requirements/dev-requirements.txt
+++ b/lambda_functions/v1/requirements/dev-requirements.txt
@@ -16,3 +16,4 @@ yarl
 localstack-client
 tenacity
 redis
+fakeredis

--- a/lambda_functions/v1/requirements/dev-requirements.txt
+++ b/lambda_functions/v1/requirements/dev-requirements.txt
@@ -15,3 +15,4 @@ validators
 yarl
 localstack-client
 tenacity
+redis

--- a/lambda_functions/v1/requirements/requirements.txt
+++ b/lambda_functions/v1/requirements/requirements.txt
@@ -1,5 +1,6 @@
-#Update this date to trigger update of layers: 290418
+#Update this date to trigger update of layers: 20200807
 Flask
 Werkzeug
 pyjwt
 redis
+localstack-client

--- a/lambda_functions/v1/requirements/requirements.txt
+++ b/lambda_functions/v1/requirements/requirements.txt
@@ -4,3 +4,4 @@ Werkzeug
 pyjwt
 redis
 localstack-client
+requests

--- a/lambda_functions/v1/tests/routes/conftest.py
+++ b/lambda_functions/v1/tests/routes/conftest.py
@@ -5,12 +5,13 @@ from flask import Flask
 
 from lambda_functions.v1.functions.lpa.app import api
 from lambda_functions.v1.functions.lpa.app import create_app
+from lambda_functions.v1.functions.lpa.app.config import LocalTestingConfig
 from lambda_functions.v1.tests.helpers import load_data
 
 
 @pytest.fixture(scope="session")
 def app(*args, **kwargs):
-    app = create_app(Flask)
+    app = create_app(config=LocalTestingConfig)
 
     routes = [str(p) for p in app.url_map.iter_rules()]
     print(f"routes: {routes}")
@@ -30,7 +31,7 @@ def patched_get_secret(monkeypatch):
         print("patched_get_secret returning mock_secret")
         return "this_is_a_secret_string"
 
-    monkeypatch.setattr(api.sirius_service, "get_secret", mock_secret)
+    monkeypatch.setattr(api.sirius_service.SiriusService, "_get_secret", mock_secret)
 
 
 @pytest.fixture()
@@ -74,4 +75,6 @@ def patched_send_request_to_sirius(monkeypatch):
             print("test_id is not a valid sirius_uid or lpa-online-tool id")
             return 404, ""
 
-    monkeypatch.setattr(api.sirius_service, "send_request_to_sirius", mock_get)
+    monkeypatch.setattr(
+        api.sirius_service.SiriusService, "send_request_to_sirius", mock_get
+    )

--- a/lambda_functions/v1/tests/sirius_service/conftest.py
+++ b/lambda_functions/v1/tests/sirius_service/conftest.py
@@ -1,16 +1,23 @@
 import os
 import string
 
+import fakeredis
 import pytest
 
-# Defaults to 50
+from lambda_functions.v1.functions.lpa.app.api.sirius_service import SiriusService
+from lambda_functions.v1.functions.lpa.app.config import LocalTestingConfig
 import requests
 
-from lambda_functions.v1.functions.lpa.app.api import sirius_service
 
 # Defaults to 50
-max_examples = int(os.environ["HYPOTHESIS_MAX_EXAMPLES"])
+max_examples = 50
 alphabet = list(string.ascii_letters + string.digits + string.punctuation)
+
+
+test_redis_handler = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+test_sirius_service = SiriusService(
+    config_params=LocalTestingConfig, cache=test_redis_handler
+)
 
 
 @pytest.fixture()
@@ -19,7 +26,7 @@ def patched_get_secret(monkeypatch):
         print("patched_get_secret returning mock_secret")
         return "this_is_a_secret_string"
 
-    monkeypatch.setattr(sirius_service, "get_secret", mock_secret)
+    monkeypatch.setattr(test_sirius_service, "_get_secret", mock_secret)
 
 
 @pytest.fixture()
@@ -31,7 +38,7 @@ def patched_build_sirius_headers(monkeypatch):
             "Authorization": "Bearer not-a-real-token",
         }
 
-    monkeypatch.setattr(sirius_service, "build_sirius_headers", mock_headers)
+    monkeypatch.setattr(test_sirius_service, "_build_sirius_headers", mock_headers)
 
 
 @pytest.fixture()

--- a/lambda_functions/v1/tests/sirius_service/conftest.py
+++ b/lambda_functions/v1/tests/sirius_service/conftest.py
@@ -1,4 +1,5 @@
 import os
+import string
 
 import pytest
 
@@ -9,8 +10,7 @@ from lambda_functions.v1.functions.lpa.app.api import sirius_service
 
 # Defaults to 50
 max_examples = int(os.environ["HYPOTHESIS_MAX_EXAMPLES"])
-
-max_examples = int(os.environ["HYPOTHESIS_MAX_EXAMPLES"])
+alphabet = list(string.ascii_letters + string.digits + string.punctuation)
 
 
 @pytest.fixture()

--- a/lambda_functions/v1/tests/sirius_service/test_build_sirius_headers.py
+++ b/lambda_functions/v1/tests/sirius_service/test_build_sirius_headers.py
@@ -2,7 +2,7 @@ import jwt
 import pytest
 from hypothesis import given, example
 
-from lambda_functions.v1.functions.lpa.app.api import sirius_service
+from lambda_functions.v1.tests.sirius_service.conftest import test_sirius_service
 from lambda_functions.v1.tests.sirius_service.strategies import content_type
 
 
@@ -18,16 +18,18 @@ def test_build_sirius_headers_content_type(
     test_content_type, test_secret_key, expected_content_type, patched_get_secret
 ):
     if test_content_type:
-        headers = sirius_service.build_sirius_headers(content_type=test_content_type)
+        headers = test_sirius_service._build_sirius_headers(
+            content_type=test_content_type
+        )
     else:
-        headers = sirius_service.build_sirius_headers()
+        headers = test_sirius_service._build_sirius_headers()
 
     assert headers["Content-Type"] == expected_content_type
 
 
 def test_build_sirius_headers_auth(patched_get_secret):
 
-    headers = sirius_service.build_sirius_headers()
+    headers = test_sirius_service._build_sirius_headers()
     token = headers["Authorization"].split()[1]
 
     try:
@@ -46,12 +48,12 @@ def test_build_sirius_headers_content_type_hypothesis(
 ):
     default_content_type = "application/json"
 
-    headers = sirius_service.build_sirius_headers(content_type=test_content_type)
+    headers = test_sirius_service._build_sirius_headers(content_type=test_content_type)
 
     if test_content_type:
         assert headers["Content-Type"] == test_content_type
     else:
         assert headers["Content-Type"] == default_content_type
 
-        headers_no_content = sirius_service.build_sirius_headers()
+        headers_no_content = test_sirius_service._build_sirius_headers()
         assert headers_no_content["Content-Type"] == default_content_type

--- a/lambda_functions/v1/tests/sirius_service/test_build_sirius_url.py
+++ b/lambda_functions/v1/tests/sirius_service/test_build_sirius_url.py
@@ -1,14 +1,14 @@
 import logging
-import urllib
 
 import hypothesis.strategies as st
 import pytest
 import validators
 from hypothesis import given, settings, example
 
-from lambda_functions.v1.functions.lpa.app.api import sirius_service
-
-# from lambda_functions.v1.tests.sirius_service.conftest import max_examples
+from lambda_functions.v1.tests.sirius_service.conftest import (
+    max_examples,
+    test_sirius_service,
+)
 
 
 @given(
@@ -21,11 +21,11 @@ from lambda_functions.v1.functions.lpa.app.api import sirius_service
         "metadata[report_id]": "d0a43b67-3084-4a74-ab55-a7542cfadd37",
     },
 )
-@settings(max_examples=50)
+@settings(max_examples=max_examples)
 def test_build_sirius_url_with_hypothesis(endpoint, url_params, caplog):
 
     print(f"endpoint: {endpoint}")
-    url = sirius_service.build_sirius_url(endpoint, url_params)
+    url = test_sirius_service.build_sirius_url(endpoint, url_params)
 
     assert validators.url(url)
 
@@ -34,7 +34,7 @@ def test_build_sirius_url_missing_env_var(monkeypatch, caplog):
     monkeypatch.delenv("SIRIUS_BASE_URL")
 
     with pytest.raises(Exception):
-        sirius_service.build_sirius_url(endpoint="")
+        test_sirius_service.build_sirius_url(endpoint="")
 
         with caplog.at_level(logging.ERROR):
             assert "Unable to build Sirius URL" in caplog.text

--- a/lambda_functions/v1/tests/sirius_service/test_constructor.py
+++ b/lambda_functions/v1/tests/sirius_service/test_constructor.py
@@ -56,3 +56,11 @@ def test_constructor_defaults():
 
     assert test_sirius_service.request_caching_name == "default_sirius_cache"
     assert test_sirius_service.request_caching_ttl == 48
+
+
+def test_constructor_redis_not_connected():
+
+    test_sirius_service = SiriusService(config_params=LocalTestingConfig, cache=None)
+
+    print(f"test_sirius_service: {test_sirius_service}")
+    assert test_sirius_service.request_caching == "disabled"

--- a/lambda_functions/v1/tests/sirius_service/test_constructor.py
+++ b/lambda_functions/v1/tests/sirius_service/test_constructor.py
@@ -1,0 +1,58 @@
+import json
+import logging
+
+import fakeredis
+import pytest
+
+from lambda_functions.v1.functions.lpa.app.api.sirius_service import SiriusService
+from lambda_functions.v1.functions.lpa.app.config import LocalTestingConfig, Config
+
+
+def test_constructor():
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True
+    )
+    test_sirius_service = SiriusService(
+        config_params=LocalTestingConfig, cache=test_redis_handler
+    )
+
+    assert test_sirius_service.cache is not None
+    assert test_sirius_service.sirius_base_url is not None
+    assert test_sirius_service.environment is not None
+    assert test_sirius_service.session_data is not None
+    assert test_sirius_service.redis_url is not None
+    assert test_sirius_service.request_caching is not None
+    assert test_sirius_service.request_caching_name is not None
+    assert test_sirius_service.request_caching_ttl is not None
+
+
+class BrokenConfig(Config):
+    del Config.SIRIUS_BASE_URL
+
+
+def test_constructor_broken(caplog):
+
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True
+    )
+    SiriusService(config_params=BrokenConfig, cache=test_redis_handler)
+
+    with caplog.at_level("INFO"):
+        assert "Error loading config" in caplog.text
+
+
+class EmptyConfig(LocalTestingConfig):
+    REQUEST_CACHE_NAME = None
+    REQUEST_CACHING_TTL = None
+
+
+def test_constructor_defaults():
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True
+    )
+    test_sirius_service = SiriusService(
+        config_params=EmptyConfig, cache=test_redis_handler
+    )
+
+    assert test_sirius_service.request_caching_name == "default_sirius_cache"
+    assert test_sirius_service.request_caching_ttl == 48

--- a/lambda_functions/v1/tests/sirius_service/test_constructor.py
+++ b/lambda_functions/v1/tests/sirius_service/test_constructor.py
@@ -20,7 +20,6 @@ def test_constructor():
     assert test_sirius_service.sirius_base_url is not None
     assert test_sirius_service.environment is not None
     assert test_sirius_service.session_data is not None
-    assert test_sirius_service.redis_url is not None
     assert test_sirius_service.request_caching is not None
     assert test_sirius_service.request_caching_name is not None
     assert test_sirius_service.request_caching_ttl is not None

--- a/lambda_functions/v1/tests/sirius_service/test_get_data_from_sirius.py
+++ b/lambda_functions/v1/tests/sirius_service/test_get_data_from_sirius.py
@@ -22,13 +22,13 @@ from lambda_functions.v1.tests.sirius_service.strategies import (
 @example(url="http://not-an-url.com", method="POST", content_type=None, data=None)
 @example(url="http://not-an-url.com", method="PUT", content_type=None, data=None)
 @settings(max_examples=max_examples)
-def test_send_request_to_sirius(
+def test_get_data_from_sirius(
     url, method, content_type, data, patched_build_sirius_headers, patched_requests
 ):
 
     default_content_type = "application/json"
 
-    result_status, result_data = sirius_service.send_request_to_sirius(
+    result_status, result_data = sirius_service.get_data_from_sirius(
         url=url, method=method, content_type=content_type, data=json.dumps(data)
     )
 
@@ -44,13 +44,13 @@ def test_send_request_to_sirius(
         assert result_data["data"] is None
 
 
-def test_send_request_to_sirius_bad_method(
+def test_get_data_from_sirius_bad_method(
     patched_build_sirius_headers, patched_requests
 ):
     url = "http://not-an-url.com"
     method = "banana"
 
-    result_status, result_data = sirius_service.send_request_to_sirius(
+    result_status, result_data = sirius_service.get_data_from_sirius(
         url=url, method=method
     )
 
@@ -62,13 +62,13 @@ def test_send_request_to_sirius_bad_method(
     )
 
 
-def test_send_request_to_sirius_exception(
+def test_get_data_from_sirius_exception(
     patched_build_sirius_headers, patched_requests_broken, caplog
 ):
     url = "http://not-an-url.com"
     method = "GET"
 
-    result_status, result_data = sirius_service.send_request_to_sirius(
+    result_status, result_data = sirius_service.get_data_from_sirius(
         url=url, method=method
     )
     assert result_status == 500

--- a/lambda_functions/v1/tests/sirius_service/test_get_data_from_sirius.py
+++ b/lambda_functions/v1/tests/sirius_service/test_get_data_from_sirius.py
@@ -4,12 +4,14 @@ import logging
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings, example
-from lambda_functions.v1.functions.lpa.app.api import sirius_service
+
 from lambda_functions.v1.tests.sirius_service.conftest import max_examples
 from lambda_functions.v1.tests.sirius_service.strategies import (
     url_as_string,
     content_type,
 )
+
+from lambda_functions.v1.tests.sirius_service.conftest import test_sirius_service
 
 
 @given(
@@ -28,7 +30,7 @@ def test_get_data_from_sirius(
 
     default_content_type = "application/json"
 
-    result_status, result_data = sirius_service.get_data_from_sirius(
+    result_status, result_data = test_sirius_service._get_data_from_sirius(
         url=url, method=method, content_type=content_type, data=json.dumps(data)
     )
 
@@ -50,7 +52,7 @@ def test_get_data_from_sirius_bad_method(
     url = "http://not-an-url.com"
     method = "banana"
 
-    result_status, result_data = sirius_service.get_data_from_sirius(
+    result_status, result_data = test_sirius_service._get_data_from_sirius(
         url=url, method=method
     )
 
@@ -68,7 +70,7 @@ def test_get_data_from_sirius_exception(
     url = "http://not-an-url.com"
     method = "GET"
 
-    result_status, result_data = sirius_service.get_data_from_sirius(
+    result_status, result_data = test_sirius_service._get_data_from_sirius(
         url=url, method=method
     )
     assert result_status == 500

--- a/lambda_functions/v1/tests/sirius_service/test_get_secret.py
+++ b/lambda_functions/v1/tests/sirius_service/test_get_secret.py
@@ -3,7 +3,7 @@ import pytest
 from botocore.exceptions import ClientError
 from moto import mock_secretsmanager
 
-from lambda_functions.v1.functions.lpa.app.api import sirius_service
+from lambda_functions.v1.tests.sirius_service.conftest import test_sirius_service
 
 
 @pytest.mark.parametrize(
@@ -17,7 +17,10 @@ def test_get_secret(secret_code, environment, region):
     client = session.client(service_name="secretsmanager", region_name=region)
 
     client.create_secret(Name=f"{environment}/jwt-key", SecretString=secret_code)
-    assert sirius_service.get_secret(environment) == secret_code
+
+    test_sirius_service.environment = environment
+    assert test_sirius_service._get_secret() == secret_code
 
     with pytest.raises(ClientError):
-        sirius_service.get_secret("not_a_real_environment")
+        test_sirius_service.environment = "not_a_real_env"
+        test_sirius_service._get_secret()

--- a/lambda_functions/v1/tests/sirius_service/test_get_sirius_data_from_cache.py
+++ b/lambda_functions/v1/tests/sirius_service/test_get_sirius_data_from_cache.py
@@ -1,0 +1,72 @@
+import json
+
+import fakeredis
+import hypothesis.strategies as st
+from hypothesis import settings, given
+
+from lambda_functions.v1.functions.lpa.app.api import sirius_service
+from lambda_functions.v1.tests.sirius_service.conftest import max_examples, alphabet
+
+
+@given(
+    test_key_name=st.text(min_size=1, alphabet=alphabet),
+    test_key=st.text(min_size=1),
+    test_data=st.dictionaries(
+        st.text(min_size=1), st.text(min_size=1), min_size=1, max_size=10
+    ),
+)
+@settings(max_examples=max_examples)
+def test_get_sirius_data_from_cache(monkeypatch, test_key_name, test_key, test_data):
+
+    monkeypatch.setenv("REQUEST_CACHING_NAME", test_key_name)
+
+    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+
+    full_key = f"{test_key_name}-{test_key}"
+    r.set(name=full_key, value=json.dumps(test_data))
+
+    status_code, result_data = sirius_service.get_sirius_data_from_cache(
+        redis_conn=r, key=test_key
+    )
+
+    assert status_code == 200
+    assert result_data == test_data
+
+
+def test_get_sirius_data_from_cache_missing_env_var(monkeypatch):
+    test_key = "test_key"
+    test_data = [{"test": "data"}]
+    monkeypatch.delenv("REQUEST_CACHING_NAME")
+
+    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+
+    full_key = f"default_sirius_cache-{test_key}"
+    r.set(name=full_key, value=json.dumps(test_data))
+
+    result = r.get(full_key)
+    print(f"result: {type(result)}")
+    print(f"json.loads(result): {json.loads(result)}")
+
+    status_code, result_data = sirius_service.get_sirius_data_from_cache(
+        redis_conn=r, key=test_key
+    )
+
+    assert status_code == 200
+    assert result_data == test_data
+
+
+def test_get_sirius_data_from_cache_redis_ded(monkeypatch):
+
+    test_key_name = "test_key_name"
+    test_key = "test_key"
+
+    monkeypatch.setenv("REQUEST_CACHING_NAME", test_key_name)
+
+    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+
+    status_code, result_data = sirius_service.get_sirius_data_from_cache(
+        redis_conn=r, key=test_key
+    )
+
+    assert status_code == 500
+    assert result_data is None

--- a/lambda_functions/v1/tests/sirius_service/test_get_sirius_data_from_cache.py
+++ b/lambda_functions/v1/tests/sirius_service/test_get_sirius_data_from_cache.py
@@ -1,11 +1,13 @@
 import json
 
-import fakeredis
 import hypothesis.strategies as st
 from hypothesis import settings, given
 
-from lambda_functions.v1.functions.lpa.app.api import sirius_service
-from lambda_functions.v1.tests.sirius_service.conftest import max_examples, alphabet
+from lambda_functions.v1.tests.sirius_service.conftest import (
+    max_examples,
+    alphabet,
+    test_sirius_service,
+)
 
 
 @given(
@@ -18,41 +20,20 @@ from lambda_functions.v1.tests.sirius_service.conftest import max_examples, alph
 @settings(max_examples=max_examples)
 def test_get_sirius_data_from_cache(monkeypatch, test_key_name, test_key, test_data):
 
-    monkeypatch.setenv("REQUEST_CACHING_NAME", test_key_name)
-
-    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+    test_sirius_service.request_caching_name = test_key_name
+    test_cache = test_sirius_service.cache
 
     full_key = f"{test_key_name}-{test_key}"
-    r.set(name=full_key, value=json.dumps(test_data))
+    test_cache.set(name=full_key, value=json.dumps(test_data))
 
-    status_code, result_data = sirius_service.get_sirius_data_from_cache(
-        redis_conn=r, key=test_key
+    status_code, result_data = test_sirius_service._get_sirius_data_from_cache(
+        redis_conn=test_cache, key=test_key
     )
 
     assert status_code == 200
     assert result_data == test_data
 
-
-def test_get_sirius_data_from_cache_missing_env_var(monkeypatch):
-    test_key = "test_key"
-    test_data = [{"test": "data"}]
-    monkeypatch.delenv("REQUEST_CACHING_NAME")
-
-    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
-
-    full_key = f"default_sirius_cache-{test_key}"
-    r.set(name=full_key, value=json.dumps(test_data))
-
-    result = r.get(full_key)
-    print(f"result: {type(result)}")
-    print(f"json.loads(result): {json.loads(result)}")
-
-    status_code, result_data = sirius_service.get_sirius_data_from_cache(
-        redis_conn=r, key=test_key
-    )
-
-    assert status_code == 200
-    assert result_data == test_data
+    test_cache.flushall()
 
 
 def test_get_sirius_data_from_cache_redis_ded(monkeypatch):
@@ -60,13 +41,15 @@ def test_get_sirius_data_from_cache_redis_ded(monkeypatch):
     test_key_name = "test_key_name"
     test_key = "test_key"
 
-    monkeypatch.setenv("REQUEST_CACHING_NAME", test_key_name)
+    test_sirius_service.request_caching_name = test_key_name
 
-    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+    test_cache = test_sirius_service.cache
 
-    status_code, result_data = sirius_service.get_sirius_data_from_cache(
-        redis_conn=r, key=test_key
+    status_code, result_data = test_sirius_service._get_sirius_data_from_cache(
+        redis_conn=test_cache, key=test_key
     )
 
     assert status_code == 500
     assert result_data is None
+
+    test_cache.flushall()

--- a/lambda_functions/v1/tests/sirius_service/test_handle_sirius_error.py
+++ b/lambda_functions/v1/tests/sirius_service/test_handle_sirius_error.py
@@ -4,8 +4,11 @@ import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
 
-from lambda_functions.v1.functions.lpa.app.api import sirius_service
-from lambda_functions.v1.tests.sirius_service.conftest import max_examples
+
+from lambda_functions.v1.tests.sirius_service.conftest import (
+    max_examples,
+    test_sirius_service,
+)
 
 
 @given(
@@ -22,7 +25,7 @@ def test_handle_sirius_error_with_hypothesis(
     default_message = "Unknown error talking to Sirius"
     default_details = None
 
-    code, message = sirius_service.handle_sirius_error(
+    code, message = test_sirius_service._handle_sirius_error(
         error_code=test_error_code,
         error_message=test_error_message,
         error_details=test_error_details,

--- a/lambda_functions/v1/tests/sirius_service/test_put_sirius_data_in_cache.py
+++ b/lambda_functions/v1/tests/sirius_service/test_put_sirius_data_in_cache.py
@@ -4,8 +4,15 @@ import fakeredis
 import hypothesis.strategies as st
 from hypothesis import settings, given
 
-from lambda_functions.v1.functions.lpa.app.api import sirius_service
-from lambda_functions.v1.tests.sirius_service.conftest import max_examples, alphabet
+
+from lambda_functions.v1.tests.sirius_service.conftest import (
+    max_examples,
+    alphabet,
+    test_sirius_service,
+)
+
+
+test_cache = test_sirius_service.cache
 
 
 @given(
@@ -17,44 +24,18 @@ from lambda_functions.v1.tests.sirius_service.conftest import max_examples, alph
     test_ttl=st.integers(min_value=1, max_value=100),
 )
 @settings(max_examples=max_examples)
-def test_put_sirius_data_in_cache(
-    monkeypatch, test_key_name, test_key, test_data, test_ttl
-):
+def test_put_sirius_data_in_cache(test_key_name, test_key, test_data, test_ttl):
 
-    monkeypatch.setenv("REQUEST_CACHING_NAME", test_key_name)
-    monkeypatch.setenv("REQUEST_CACHING_TTL", str(test_ttl))
+    test_sirius_service.request_caching_name = test_key_name
+    test_sirius_service.request_caching_ttl = test_ttl
 
-    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
-
-    sirius_service.put_sirius_data_in_cache(
-        redis_conn=r, key=test_key, data=json.dumps(test_data)
+    test_sirius_service._put_sirius_data_in_cache(
+        redis_conn=test_cache, key=test_key, data=json.dumps(test_data)
     )
 
     full_key = f"{test_key_name}-{test_key}"
 
-    assert json.loads(json.loads(r.get(full_key))) == test_data
-    assert r.ttl(full_key) == test_ttl * 60 * 60
+    assert json.loads(json.loads(test_cache.get(full_key))) == test_data
+    assert test_cache.ttl(full_key) == test_ttl * 60 * 60
 
-    r.flushall()
-
-
-def test_put_sirius_data_in_cache_missing_env_vars(monkeypatch):
-
-    monkeypatch.delenv("REQUEST_CACHING_NAME")
-    monkeypatch.delenv("REQUEST_CACHING_TTL")
-
-    test_key = "test_key"
-    test_data = {"test": "data"}
-
-    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
-
-    sirius_service.put_sirius_data_in_cache(
-        redis_conn=r, key=test_key, data=json.dumps(test_data)
-    )
-
-    full_key = f"default_sirius_cache-{test_key}"
-
-    assert json.loads(json.loads(r.get(full_key))) == test_data
-    assert r.ttl(full_key) == 48 * 60 * 60
-
-    r.flushall()
+    test_cache.flushall()

--- a/lambda_functions/v1/tests/sirius_service/test_put_sirius_data_in_cache.py
+++ b/lambda_functions/v1/tests/sirius_service/test_put_sirius_data_in_cache.py
@@ -1,0 +1,60 @@
+import json
+
+import fakeredis
+import hypothesis.strategies as st
+from hypothesis import settings, given
+
+from lambda_functions.v1.functions.lpa.app.api import sirius_service
+from lambda_functions.v1.tests.sirius_service.conftest import max_examples, alphabet
+
+
+@given(
+    test_key_name=st.text(min_size=1, alphabet=alphabet),
+    test_key=st.text(min_size=1),
+    test_data=st.dictionaries(
+        st.text(min_size=1), st.text(min_size=1), min_size=1, max_size=10
+    ),
+    test_ttl=st.integers(min_value=1, max_value=100),
+)
+@settings(max_examples=max_examples)
+def test_put_sirius_data_in_cache(
+    monkeypatch, test_key_name, test_key, test_data, test_ttl
+):
+
+    monkeypatch.setenv("REQUEST_CACHING_NAME", test_key_name)
+    monkeypatch.setenv("REQUEST_CACHING_TTL", str(test_ttl))
+
+    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+
+    sirius_service.put_sirius_data_in_cache(
+        redis_conn=r, key=test_key, data=json.dumps(test_data)
+    )
+
+    full_key = f"{test_key_name}-{test_key}"
+
+    assert json.loads(json.loads(r.get(full_key))) == test_data
+    assert r.ttl(full_key) == test_ttl * 60 * 60
+
+    r.flushall()
+
+
+def test_put_sirius_data_in_cache_missing_env_vars(monkeypatch):
+
+    monkeypatch.delenv("REQUEST_CACHING_NAME")
+    monkeypatch.delenv("REQUEST_CACHING_TTL")
+
+    test_key = "test_key"
+    test_data = {"test": "data"}
+
+    r = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+
+    sirius_service.put_sirius_data_in_cache(
+        redis_conn=r, key=test_key, data=json.dumps(test_data)
+    )
+
+    full_key = f"default_sirius_cache-{test_key}"
+
+    assert json.loads(json.loads(r.get(full_key))) == test_data
+    assert r.ttl(full_key) == 48 * 60 * 60
+
+    r.flushall()

--- a/lambda_functions/v1/tests/sirius_service/test_send_request_to_sirius.py
+++ b/lambda_functions/v1/tests/sirius_service/test_send_request_to_sirius.py
@@ -1,0 +1,262 @@
+import logging
+
+import pytest
+
+from lambda_functions.v1.functions.lpa.app.api import sirius_service
+from lambda_functions.v1.functions.lpa.app.api.sirius_service import (
+    send_request_to_sirius,
+)
+
+
+@pytest.mark.parametrize(
+    "method, expected_status_code", [("GET", 200), ("POST", 200), ("PUT", 200)]
+)
+def test_send_request_to_sirius(monkeypatch, caplog, method, expected_status_code):
+    """
+    Sirius is available, cache enabled, request works and puts data in cache
+    """
+
+    monkeypatch.setenv("REQUEST_CACHING", "enabled")
+    monkeypatch.setattr(sirius_service, "check_sirius_available", lambda: True)
+    monkeypatch.setattr(
+        sirius_service, "get_data_from_sirius", lambda x, y, z, p: (200, "OK")
+    )
+    monkeypatch.setattr(sirius_service, "put_sirius_data_in_cache", lambda x, y: True)
+
+    key = "test_key"
+    url = "http://not-an-url.com"
+
+    result_status_code, result_data = send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    with caplog.at_level(logging.INFO):
+        if method == "GET":
+            assert "Putting data in cache with key" in caplog.text
+        else:
+            assert "Putting data in cache with key" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "method, expected_status_code", [("GET", 200), ("POST", 200), ("PUT", 200)]
+)
+def test_send_request_to_sirius_no_cache(
+    monkeypatch, caplog, method, expected_status_code
+):
+    """
+    Sirius is available, cache disabled, request works
+    """
+
+    monkeypatch.setenv("REQUEST_CACHING", "disabled")
+    monkeypatch.setattr(sirius_service, "check_sirius_available", lambda: True)
+    monkeypatch.setattr(
+        sirius_service, "get_data_from_sirius", lambda x, y, z, p: (200, "OK")
+    )
+    monkeypatch.setattr(sirius_service, "put_sirius_data_in_cache", lambda x, y: True)
+
+    key = "test_key"
+    url = "http://not-an-url.com"
+
+    result_status_code, result_data = send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    with caplog.at_level(logging.INFO):
+        assert "Putting data in cache with key" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "method, expected_status_code", [("GET", 200), ("POST", 200), ("PUT", 200)]
+)
+def test_send_request_to_sirius_no_cache_env_var(
+    monkeypatch, caplog, method, expected_status_code
+):
+    """
+    Sirius is available, cache disabled, request works
+    """
+
+    monkeypatch.delenv("REQUEST_CACHING")
+    monkeypatch.setattr(sirius_service, "check_sirius_available", lambda: True)
+    monkeypatch.setattr(
+        sirius_service, "get_data_from_sirius", lambda x, y, z, p: (200, "OK")
+    )
+    monkeypatch.setattr(sirius_service, "put_sirius_data_in_cache", lambda x, y: True)
+
+    key = "test_key"
+    url = "http://not-an-url.com"
+
+    result_status_code, result_data = send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    with caplog.at_level(logging.INFO):
+        assert "Putting data in cache with key" not in caplog.text
+
+
+# TODO should this 500 when the GET fails or should it try the cache?
+@pytest.mark.parametrize(
+    "method, expected_status_code", [("GET", 500), ("POST", 500), ("PUT", 500)]
+)
+def test_send_request_to_sirius_request_fails(
+    monkeypatch, caplog, method, expected_status_code
+):
+    """
+    Sirius is available, cache enabled,  request fails
+    """
+
+    monkeypatch.setenv("REQUEST_CACHING", "enabled")
+    monkeypatch.setattr(sirius_service, "check_sirius_available", lambda: True)
+    monkeypatch.setattr(
+        sirius_service, "get_data_from_sirius", lambda x, y, z, p: (500, "error")
+    )
+    monkeypatch.setattr(sirius_service, "put_sirius_data_in_cache", lambda x, y: True)
+
+    key = "test_key"
+    url = "http://not-an-url.com"
+
+    result_status_code, result_data = send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    with caplog.at_level(logging.INFO):
+        "Putting data in cache with key" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "method, expected_status_code", [("GET", 500), ("POST", 500), ("PUT", 500)]
+)
+def test_send_request_to_sirius_no_cache_request_fails(
+    monkeypatch, caplog, method, expected_status_code
+):
+    """
+    Sirius is available, cache disabled, request fails
+    """
+
+    monkeypatch.setenv("REQUEST_CACHING", "disabled")
+    monkeypatch.setattr(sirius_service, "check_sirius_available", lambda: True)
+    monkeypatch.setattr(
+        sirius_service, "get_data_from_sirius", lambda x, y, z, p: (500, "error")
+    )
+    monkeypatch.setattr(sirius_service, "put_sirius_data_in_cache", lambda x, y: True)
+
+    key = "test_key"
+    url = "http://not-an-url.com"
+
+    result_status_code, result_data = send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    with caplog.at_level(logging.INFO):
+        assert "Putting data in cache with key" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "method, expected_status_code", [("GET", 200), ("POST", 500), ("PUT", 500)]
+)
+def test_send_request_to_sirius_but_sirius_is_broken(
+    monkeypatch, caplog, method, expected_status_code
+):
+    """
+    Sirius is not available, cache enabled, request fails, cache works
+    """
+
+    monkeypatch.setenv("REQUEST_CACHING", "enabled")
+    monkeypatch.setattr(sirius_service, "check_sirius_available", lambda: False)
+    monkeypatch.setattr(
+        sirius_service, "get_data_from_sirius", lambda x, y, z, p: (500, "errpr")
+    )
+    monkeypatch.setattr(
+        sirius_service, "get_sirius_data_from_cache", lambda x: (200, {"test": "data"})
+    )
+
+    key = "test_key"
+    url = "http://not-an-url.com"
+
+    result_status_code, result_data = send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    with caplog.at_level(logging.INFO):
+        if method == "GET":
+            assert "Getting data from cache with key" in caplog.text
+        else:
+            assert "Getting data from cache with key" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "method, expected_status_code", [("GET", 500), ("POST", 500), ("PUT", 500)]
+)
+def test_send_request_to_sirius_but_sirius_is_broken_value_not_in_cache(
+    monkeypatch, caplog, method, expected_status_code
+):
+    """
+    Sirius is not available, cache enabled, request fails and value not in cache
+    """
+
+    monkeypatch.setenv("REQUEST_CACHING", "enabled")
+    monkeypatch.setattr(sirius_service, "check_sirius_available", lambda: False)
+    monkeypatch.setattr(
+        sirius_service, "get_data_from_sirius", lambda x, y, z, p: (500, "errpr")
+    )
+    monkeypatch.setattr(
+        sirius_service, "get_sirius_data_from_cache", lambda x: (500, None)
+    )
+
+    key = "test_key"
+    url = "http://not-an-url.com"
+
+    result_status_code, result_data = send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    with caplog.at_level(logging.INFO):
+        if method == "GET":
+            assert "Getting data from cache with key" in caplog.text
+        else:
+            assert "Getting data from cache with key" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    "method, expected_status_code", [("GET", 500), ("POST", 500), ("PUT", 500)]
+)
+def test_send_request_to_sirius_but_sirius_is_broken_and_cache_disabled(
+    monkeypatch, caplog, method, expected_status_code
+):
+    """
+    Sirius is not available, cache disabled, request works, cache works
+    """
+
+    monkeypatch.setenv("REQUEST_CACHING", "disabled")
+    monkeypatch.setattr(sirius_service, "check_sirius_available", lambda: False)
+    monkeypatch.setattr(
+        sirius_service, "get_data_from_sirius", lambda x, y, z, p: (500, "error")
+    )
+    monkeypatch.setattr(
+        sirius_service, "get_sirius_data_from_cache", lambda x: (200, {"test": "data"})
+    )
+
+    key = "test_key"
+    url = "http://not-an-url.com"
+
+    result_status_code, result_data = send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    with caplog.at_level(logging.INFO):
+        assert "Getting data from cache with key" not in caplog.text

--- a/lambda_functions/v1/tests/sirius_service/test_sirius_available.py
+++ b/lambda_functions/v1/tests/sirius_service/test_sirius_available.py
@@ -1,8 +1,7 @@
-from lambda_functions.v1.functions.lpa.app.api.sirius_service import (
-    check_sirius_available,
-)
 import pytest
 import requests
+
+from lambda_functions.v1.tests.sirius_service.conftest import test_sirius_service
 
 
 @pytest.fixture
@@ -28,12 +27,12 @@ def patched_sirius_heathcheck_broken(monkeypatch):
 
 
 def test_check_sirius_available(patched_sirius_heathcheck):
-    result = check_sirius_available()
+    result = test_sirius_service._check_sirius_available()
 
     assert result is True
 
 
 def test_check_sirius_not_available(patched_sirius_heathcheck_broken):
-    result = check_sirius_available()
+    result = test_sirius_service._check_sirius_available()
 
     assert result is False

--- a/lambda_functions/v1/tests/sirius_service/test_sirius_available.py
+++ b/lambda_functions/v1/tests/sirius_service/test_sirius_available.py
@@ -1,0 +1,39 @@
+from lambda_functions.v1.functions.lpa.app.api.sirius_service import (
+    check_sirius_available,
+)
+import pytest
+import requests
+
+
+@pytest.fixture
+def patched_sirius_heathcheck(monkeypatch):
+    def mock_healthcheck(*args, **kwargs):
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+
+        return mock_response
+
+    monkeypatch.setattr(requests, "get", mock_healthcheck)
+
+
+@pytest.fixture
+def patched_sirius_heathcheck_broken(monkeypatch):
+    def mock_healthcheck(*args, **kwargs):
+        mock_response = requests.Response()
+        mock_response.status_code = 404
+
+        return mock_response
+
+    monkeypatch.setattr(requests, "get", mock_healthcheck)
+
+
+def test_check_sirius_available(patched_sirius_heathcheck):
+    result = check_sirius_available()
+
+    assert result is True
+
+
+def test_check_sirius_not_available(patched_sirius_heathcheck_broken):
+    result = check_sirius_available()
+
+    assert result is False

--- a/mock_sirius_backend/api/lpas/mock_data/lpa_online_tool_response.json
+++ b/mock_sirius_backend/api/lpas/mock_data/lpa_online_tool_response.json
@@ -1,7 +1,125 @@
 {
-    "onlineLpaId": "A39721583862",
-    "receiptDate": "2017-04-11",
+    "applicationHasGuidance": false,
+    "applicationHasRestrictions": false,
+    "applicationType": "Classic",
+    "attorneyActDecisions": null,
+    "attorneys": [
+        {
+            "addresses": [
+                {
+                    "addressLine1": "25 Cambridge Road",
+                    "addressLine2": "CHATTERIS",
+                    "addressLine3": "",
+                    "country": "",
+                    "county": "",
+                    "id": 7,
+                    "postcode": "PE4 7DH",
+                    "town": "",
+                    "type": "Primary"
+                }
+            ],
+            "companyName": null,
+            "dob": "1972-05-10",
+            "email": "bodge@hotmail.com",
+            "firstname": "Trevor",
+            "id": 7,
+            "middlenames": null,
+            "salutation": "Mr",
+            "surname": "Bodger",
+            "systemStatus": true,
+            "uId": "7000-0000-0104"
+        }
+    ],
+    "cancellationDate": null,
+    "caseAttorneyJointly": false,
+    "caseAttorneyJointlyAndJointlyAndSeverally": false,
+    "caseAttorneyJointlyAndSeverally": true,
+    "caseAttorneySingular": false,
+    "caseSubtype": "pfa",
+    "certificateProviders": [
+        {
+            "addresses": [
+                {
+                    "addressLine1": "32 Jamestown Street",
+                    "addressLine2": "ABLEFIELD",
+                    "addressLine3": "",
+                    "country": "",
+                    "county": "",
+                    "id": 5,
+                    "postcode": "AB2 8KJ",
+                    "town": "",
+                    "type": "Primary"
+                }
+            ],
+            "dob": null,
+            "email": null,
+            "firstname": "Julian",
+            "id": 5,
+            "middlenames": null,
+            "salutation": "Mr",
+            "surname": "Salford",
+            "uId": "7000-0000-0088"
+        }
+    ],
+    "donor": {
+        "addresses": [
+            {
+                "addressLine1": "lxzraboqaxnygvbfnbcrdozklqfzpsycwegllkkuubywvvyvjj",
+                "addressLine2": "SOLLINGSBURY",
+                "addressLine3": "",
+                "country": "",
+                "county": "",
+                "id": 1,
+                "postcode": "cytxlxdequ",
+                "town": "",
+                "type": "Primary"
+            }
+        ],
+        "companyName": null,
+        "dob": "1952-07-17",
+        "email": "sally.fathing@opgtest.com",
+        "firstname": "changeme",
+        "id": 1,
+        "middlenames": "Lucille",
+        "salutation": "Mrs",
+        "surname": "changeme",
+        "uId": "7000-0000-0047"
+    },
+    "id": 1,
+    "lifeSustainingTreatment": null,
+    "lpaDonorSignatureDate": "2020-07-15",
+    "onlineLpaId": null,
+    "receiptDate": "2014-09-26",
     "registrationDate": null,
     "rejectedDate": null,
-    "status": "Pending"
+    "replacementAttorneys": [],
+    "status": "Pending",
+    "trustCorporations": [
+        {
+            "addresses": [
+                {
+                    "addressLine1": "170 High Street",
+                    "addressLine2": "Oxford",
+                    "addressLine3": "Oxfordshire",
+                    "country": "",
+                    "county": "",
+                    "id": 6,
+                    "postcode": "OX1 1XO",
+                    "town": "",
+                    "type": "Primary"
+                }
+            ],
+            "companyName": "TrustyLaw.com",
+            "dob": null,
+            "email": "",
+            "firstname": null,
+            "id": 6,
+            "middlenames": null,
+            "salutation": null,
+            "surname": null,
+            "systemStatus": false,
+            "uId": "7000-0000-0096"
+        }
+    ],
+    "uId": "7000-0000-0013"
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,11 @@ env =
     SIRIUS_API_VERSION=v1
     SESSION_DATA=publicapi@opgtest.com
     JWT_SECRET=THIS_IS_MY_SECRET_KEY  # pragma: allowlist secret
+    LOCALSTACK_HOST=motoserver
+    REQUEST_CACHING=enabled
+    REQUEST_CACHING_TTL=48
+    REQUEST_CACHING_NAME=opg-data-lpa
+    REDIS_URL=redis://redis:6379
 markers =
     smoke_test: these tests hit the real endpoints and should not be run in CI, will fail locally if you've not got your AWS creds set properly
     pact_test: these are for pact only

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,20 +1,20 @@
 [pytest]
 env =
-    LOGGER_LEVEL=DEBUG
-    ENVIRONMENT=development
-    API_VERSION=v1
-    HYPOTHESIS_MAX_EXAMPLES=50
-    SESSION_DATA="publicapi@opgtest.com"
-    AWS_XRAY_CONTEXT_MISSING=LOG_ERROR
-    SIRIUS_BASE_URL=http://not-really-sirius.com
-    SIRIUS_API_VERSION=v1
-    SESSION_DATA=publicapi@opgtest.com
-    JWT_SECRET=THIS_IS_MY_SECRET_KEY  # pragma: allowlist secret
-    LOCALSTACK_HOST=motoserver
-    REQUEST_CACHING=enabled
-    REQUEST_CACHING_TTL=48
-    REQUEST_CACHING_NAME=opg-data-lpa
-    REDIS_URL=redis://redis:6379
+;    LOGGER_LEVEL=DEBUG
+    ENVIRONMENT=local
+;    API_VERSION=v1
+;    HYPOTHESIS_MAX_EXAMPLES=50
+;    SESSION_DATA="publicapi@opgtest.com"
+;    AWS_XRAY_CONTEXT_MISSING=LOG_ERROR
+;    SIRIUS_BASE_URL=http://not-really-sirius.com
+;    SIRIUS_API_VERSION=v1
+;    SESSION_DATA=publicapi@opgtest.com
+;    JWT_SECRET=THIS_IS_MY_SECRET_KEY  # pragma: allowlist secret
+;    LOCALSTACK_HOST=motoserver
+;    REQUEST_CACHING=enabled
+;    REQUEST_CACHING_TTL=48
+;    REQUEST_CACHING_NAME=opg-data-lpa
+;    REDIS_URL=redis://redis:6379
 markers =
     smoke_test: these tests hit the real endpoints and should not be run in CI, will fail locally if you've not got your AWS creds set properly
     pact_test: these are for pact only

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -5,8 +5,6 @@ locals {
   a_record          = local.branch_build_flag ? "${local.environment}.${data.aws_route53_zone.environment_cert.name}" : data.aws_route53_zone.environment_cert.name
   redis_c_name      = local.branch_build_flag ? "${local.environment}-redis.${data.aws_route53_zone.environment_cert.name}" : "redis.${data.aws_route53_zone.environment_cert.name}"
 
-  redis_c_name = local.branch_build_flag ? "${local.environment}-redis.${data.aws_route53_zone.environment_cert.name}" : "redis.${data.aws_route53_zone.environment_cert.name}"
-
   default_tags = {
     business-unit          = "OPG"
     application            = "Data-lpa"

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -5,6 +5,8 @@ locals {
   a_record          = local.branch_build_flag ? "${local.environment}.${data.aws_route53_zone.environment_cert.name}" : data.aws_route53_zone.environment_cert.name
   redis_c_name      = local.branch_build_flag ? "${local.environment}-redis.${data.aws_route53_zone.environment_cert.name}" : "redis.${data.aws_route53_zone.environment_cert.name}"
 
+  redis_c_name = local.branch_build_flag ? "${local.environment}-redis.${data.aws_route53_zone.environment_cert.name}" : "redis.${data.aws_route53_zone.environment_cert.name}"
+
   default_tags = {
     business-unit          = "OPG"
     application            = "Data-lpa"


### PR DESCRIPTION
## Purpose

Refactored Sirius Service into a proper class, meaning we can use a proper config object to manage options and stuff.
This is a first pass. Caching is disabled on AWS for now. Still requires a little tidy up to make it work properly (mostly getting the redis url in an env var and checking it is working) but that is for another PR

## Approach



## Learning



## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [x] I have run the integration tests (results below)
![image](https://user-images.githubusercontent.com/6086996/89895315-84c05100-dbd3-11ea-82f8-6723f0e8c25d.png)

