### PR TITLE
UML-1129

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-11-06T13:37:02Z",
+  "generated_at": "2020-11-23T10:30:06Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -58,7 +58,7 @@
       {
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
         "is_verified": false,
-        "line_number": 69,
+        "line_number": 67,
         "type": "Secret Keyword"
       }
     ]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ build:
 	./build.sh
 
 up:
-	docker-compose -f docker-compose.yml up -d --no-recreate mock-sirius motoserver api_gateway
+	docker-compose -f docker-compose.yml up -d mock-sirius motoserver api_gateway
 
 up-bridge-ual:
 	docker-compose -f docker-compose.yml -f docker-compose.bridge-ual.yml up -d --no-recreate mock-sirius motoserver api_gateway
@@ -40,4 +40,4 @@ login-api-gateway:
 	docker-compose -f docker-compose.yml exec api_gateway /bin/bash
 
 logs:
-	docker-compose -f docker-compose.yml logs -f $(c)
+	docker-compose -f docker-compose.yml logs --tail=100 -f $(c)

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,19 @@ build:
 	./build.sh
 
 up:
-	docker-compose -f docker-compose.yml up -d mock-sirius motoserver api_gateway
+	docker-compose up -d mock-sirius motoserver api_gateway
 
 up-bridge-ual:
-	docker-compose -f docker-compose.yml -f docker-compose.bridge-ual.yml up -d --no-recreate mock-sirius motoserver api_gateway
+	docker-compose -f docker-compose.yml -f docker-compose.bridge-ual.yml up -d mock-sirius motoserver api_gateway
+
+down-bridge-ual:
+	docker-compose -f docker-compose.yml -f docker-compose.bridge-ual.yml down
 
 up-all:
-	docker-compose -f docker-compose.yml up -d
+	docker-compose up -d
 
 down:
-	docker-compose -f docker-compose.yml down $(c)
+	docker-compose down $(c)
 
 setup: build up create_secrets
 
@@ -34,10 +37,10 @@ destroy:
 	docker-compose down -v --rmi all --remove-orphans
 
 ps:
-	docker-compose -f docker-compose.yml ps
+	docker-compose ps
 
 login-api-gateway:
-	docker-compose -f docker-compose.yml exec api_gateway /bin/bash
+	docker-compose exec api_gateway /bin/bash
 
 logs:
-	docker-compose -f docker-compose.yml logs --tail=100 -f $(c)
+	docker-compose logs --tail=100 -f $(c)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,10 @@ build:
 	./build.sh
 
 up:
-	docker-compose -f docker-compose.yml up -d mock-sirius motoserver api_gateway
+	docker-compose -f docker-compose.yml up -d --no-recreate mock-sirius motoserver api_gateway
+
+up-bridge-ual:
+	docker-compose -f docker-compose.yml -f docker-compose.bridge-ual.yml up -d --no-recreate mock-sirius motoserver api_gateway
 
 up-all:
 	docker-compose -f docker-compose.yml up -d
@@ -22,6 +25,8 @@ down:
 	docker-compose -f docker-compose.yml down $(c)
 
 setup: build up create_secrets
+
+setup-bridge-ual: build up-bridge-ual create_secrets
 
 setup-all: build up-all create_secrets
 
@@ -35,4 +40,4 @@ login-api-gateway:
 	docker-compose -f docker-compose.yml exec api_gateway /bin/bash
 
 logs:
-	docker-compose -f docker-compose.yml logs --tail=100 -f $(c)
+	docker-compose -f docker-compose.yml logs -f $(c)

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,6 @@
+cd $(dirname $BASH_SOURCE)
 $(aws-vault exec identity -- go run ./docs/support_scripts/aws/getcreds.go)
-docker-compose -f docker-compose.yml build \
+docker-compose -f docker-compose.yml build --no-cache \
 --build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
 --build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
 --build-arg AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 cd $(dirname $BASH_SOURCE)
 $(aws-vault exec identity -- go run ./docs/support_scripts/aws/getcreds.go)
-docker-compose -f docker-compose.yml build --no-cache \
+docker-compose -f docker-compose.yml build \
 --build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
 --build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
 --build-arg AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN

--- a/docker-compose.bridge-ual.yml
+++ b/docker-compose.bridge-ual.yml
@@ -2,6 +2,8 @@ version: "3.8"
 
 services:
   api_gateway:
+    ports:
+      - "4242:4343"
     networks:
       - default
       - opg-use-an-lpa_lpas-collection

--- a/docker-compose.bridge-ual.yml
+++ b/docker-compose.bridge-ual.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+
+services:
+  api_gateway:
+    networks:
+      - default
+      - opg-use-an-lpa_lpas-collection
+
+networks:
+  opg-use-an-lpa_lpas-collection:
+    external: true

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+
+services:
+  api_gateway:
+    ports:
+      - "4343:4343"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,3 +76,7 @@ services:
       REQUEST_CACHING_TTL: 48
       REQUEST_CACHING_NAME: opg-data-lpa
       REDIS_URL: redis://redis:6379
+    networks:
+      default:
+        aliases:
+          - lpa.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3.8"
 
 services:
   postgres:
@@ -14,8 +14,8 @@ services:
     ports:
       - "9293:80"
       - "9292:9292"
-    links:
-      - postgres
+    # links:
+    #   - postgres
     environment:
       PACT_BROKER_DATABASE_USERNAME: postgres
       PACT_BROKER_DATABASE_PASSWORD: password
@@ -53,10 +53,10 @@ services:
         AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
         AWS_SESSION_TOKEN: $AWS_SESSION_TOKEN
     ports:
-      - "4343:4343"
-    links:
-      - mock-sirius
-      - motoserver
+      - "4242:4343"
+    # links:
+    #   - mock-sirius
+    #   - motoserver
     depends_on:
       - mock-sirius
       - motoserver
@@ -78,7 +78,3 @@ services:
       REQUEST_CACHING_TTL: 48
       REQUEST_CACHING_NAME: opg-data-lpa
       REDIS_URL: redis://redis:6379
-    networks:
-      default:
-        aliases:
-          - lpa.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
     ports:
       - "9293:80"
       - "9292:9292"
-    # links:
-    #   - postgres
+    links:
+      - postgres
     environment:
       PACT_BROKER_DATABASE_USERNAME: postgres
       PACT_BROKER_DATABASE_PASSWORD: password
@@ -54,9 +54,9 @@ services:
         AWS_SESSION_TOKEN: $AWS_SESSION_TOKEN
     ports:
       - "4242:4343"
-    # links:
-    #   - mock-sirius
-    #   - motoserver
+    links:
+      - mock-sirius
+      - motoserver
     depends_on:
       - mock-sirius
       - motoserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,6 @@ services:
         AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
         AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
         AWS_SESSION_TOKEN: $AWS_SESSION_TOKEN
-    ports:
-      - "4242:4343"
     links:
       - mock-sirius
       - motoserver

--- a/mock_sirius_backend/api/lpas/handlers.py
+++ b/mock_sirius_backend/api/lpas/handlers.py
@@ -50,7 +50,8 @@ def handle_lpa_get(query_params):
             case_id = "-".join(wrap(sirius_uid, 4))
             for result in response_data["results"]:
                 if result["uId"] in case_id:
-                    return 200, result
+                    response = [result]
+                    return 200, response
 
         elif len(sirius_uid) == 3:
             print("oh no you crashed sirius")

--- a/mock_sirius_backend/api/lpas/handlers.py
+++ b/mock_sirius_backend/api/lpas/handlers.py
@@ -47,12 +47,11 @@ def handle_lpa_get(query_params):
             response_data = load_data(
                 parent_folder="lpas", filename="use_an_lpa_response.json", as_json=False
             )
-
-            response_data["uid"] = "-".join(wrap(sirius_uid, 4))
-
-            response_data = [response_data]
-
-            return 200, response_data
+            case_id = "-".join(wrap(sirius_uid, 4))
+            print(case_id)
+            for result in response_data["results"]:
+                if result["uId"] in case_id:
+                    return 200, result
 
         elif len(sirius_uid) == 3:
             print("oh no you crashed sirius")

--- a/mock_sirius_backend/api/lpas/handlers.py
+++ b/mock_sirius_backend/api/lpas/handlers.py
@@ -18,11 +18,10 @@ def handle_lpa_get(query_params):
                 as_json=False,
             )
 
-            response_data["onlineLpaId"] = lpa_online_tool_id
-
-            response_data = [response_data]
-
-            return 200, response_data
+            for result in response_data["results"]:
+                if result["onlineLpaId"] in lpa_online_tool_id:
+                    response = [result]
+                    return 200, response
 
         elif lpa_online_tool_id[:5] == "crash":
             print("oh no you crashed sirius")
@@ -47,7 +46,9 @@ def handle_lpa_get(query_params):
             response_data = load_data(
                 parent_folder="lpas", filename="use_an_lpa_response.json", as_json=False
             )
+
             case_id = "-".join(wrap(sirius_uid, 4))
+
             for result in response_data["results"]:
                 if result["uId"] in case_id:
                     response = [result]

--- a/mock_sirius_backend/api/lpas/handlers.py
+++ b/mock_sirius_backend/api/lpas/handlers.py
@@ -48,7 +48,6 @@ def handle_lpa_get(query_params):
                 parent_folder="lpas", filename="use_an_lpa_response.json", as_json=False
             )
             case_id = "-".join(wrap(sirius_uid, 4))
-            print(case_id)
             for result in response_data["results"]:
                 if result["uId"] in case_id:
                     return 200, result

--- a/mock_sirius_backend/api/lpas/mock_data/lpa_online_tool_response.json
+++ b/mock_sirius_backend/api/lpas/mock_data/lpa_online_tool_response.json
@@ -1,125 +1,129 @@
 {
-    "applicationHasGuidance": false,
-    "applicationHasRestrictions": false,
-    "applicationType": "Classic",
-    "attorneyActDecisions": null,
-    "attorneys": [
-        {
+  "results": [
+    {
+        "applicationHasGuidance": false,
+        "applicationHasRestrictions": false,
+        "applicationType": "Classic",
+        "attorneyActDecisions": null,
+        "attorneys": [
+            {
+                "addresses": [
+                    {
+                        "addressLine1": "25 Cambridge Road",
+                        "addressLine2": "CHATTERIS",
+                        "addressLine3": "",
+                        "country": "",
+                        "county": "",
+                        "id": 7,
+                        "postcode": "PE4 7DH",
+                        "town": "",
+                        "type": "Primary"
+                    }
+                ],
+                "companyName": null,
+                "dob": "1972-05-10",
+                "email": "bodge@hotmail.com",
+                "firstname": "Trevor",
+                "id": 7,
+                "middlenames": null,
+                "salutation": "Mr",
+                "surname": "Bodger",
+                "systemStatus": true,
+                "uId": "7000-0000-0104"
+            }
+        ],
+        "cancellationDate": null,
+        "caseAttorneyJointly": false,
+        "caseAttorneyJointlyAndJointlyAndSeverally": false,
+        "caseAttorneyJointlyAndSeverally": true,
+        "caseAttorneySingular": false,
+        "caseSubtype": "pfa",
+        "certificateProviders": [
+            {
+                "addresses": [
+                    {
+                        "addressLine1": "32 Jamestown Street",
+                        "addressLine2": "ABLEFIELD",
+                        "addressLine3": "",
+                        "country": "",
+                        "county": "",
+                        "id": 5,
+                        "postcode": "AB2 8KJ",
+                        "town": "",
+                        "type": "Primary"
+                    }
+                ],
+                "dob": null,
+                "email": null,
+                "firstname": "Julian",
+                "id": 5,
+                "middlenames": null,
+                "salutation": "Mr",
+                "surname": "Salford",
+                "uId": "7000-0000-0088"
+            }
+        ],
+        "donor": {
             "addresses": [
                 {
-                    "addressLine1": "25 Cambridge Road",
-                    "addressLine2": "CHATTERIS",
+                    "addressLine1": "lxzraboqaxnygvbfnbcrdozklqfzpsycwegllkkuubywvvyvjj",
+                    "addressLine2": "SOLLINGSBURY",
                     "addressLine3": "",
                     "country": "",
                     "county": "",
-                    "id": 7,
-                    "postcode": "PE4 7DH",
+                    "id": 1,
+                    "postcode": "cytxlxdequ",
                     "town": "",
                     "type": "Primary"
                 }
             ],
             "companyName": null,
-            "dob": "1972-05-10",
-            "email": "bodge@hotmail.com",
-            "firstname": "Trevor",
-            "id": 7,
-            "middlenames": null,
-            "salutation": "Mr",
-            "surname": "Bodger",
-            "systemStatus": true,
-            "uId": "7000-0000-0104"
-        }
-    ],
-    "cancellationDate": null,
-    "caseAttorneyJointly": false,
-    "caseAttorneyJointlyAndJointlyAndSeverally": false,
-    "caseAttorneyJointlyAndSeverally": true,
-    "caseAttorneySingular": false,
-    "caseSubtype": "pfa",
-    "certificateProviders": [
-        {
-            "addresses": [
-                {
-                    "addressLine1": "32 Jamestown Street",
-                    "addressLine2": "ABLEFIELD",
-                    "addressLine3": "",
-                    "country": "",
-                    "county": "",
-                    "id": 5,
-                    "postcode": "AB2 8KJ",
-                    "town": "",
-                    "type": "Primary"
-                }
-            ],
-            "dob": null,
-            "email": null,
-            "firstname": "Julian",
-            "id": 5,
-            "middlenames": null,
-            "salutation": "Mr",
-            "surname": "Salford",
-            "uId": "7000-0000-0088"
-        }
-    ],
-    "donor": {
-        "addresses": [
+            "dob": "1952-07-17",
+            "email": "sally.fathing@opgtest.com",
+            "firstname": "changeme",
+            "id": 1,
+            "middlenames": "Lucille",
+            "salutation": "Mrs",
+            "surname": "changeme",
+            "uId": "7000-0000-0047"
+        },
+        "id": 1,
+        "lifeSustainingTreatment": null,
+        "lpaDonorSignatureDate": "2020-07-15",
+        "onlineLpaId": "A39721583862",
+        "receiptDate": "2014-09-26",
+        "registrationDate": null,
+        "rejectedDate": null,
+        "replacementAttorneys": [],
+        "status": "Pending",
+        "trustCorporations": [
             {
-                "addressLine1": "lxzraboqaxnygvbfnbcrdozklqfzpsycwegllkkuubywvvyvjj",
-                "addressLine2": "SOLLINGSBURY",
-                "addressLine3": "",
-                "country": "",
-                "county": "",
-                "id": 1,
-                "postcode": "cytxlxdequ",
-                "town": "",
-                "type": "Primary"
+                "addresses": [
+                    {
+                        "addressLine1": "170 High Street",
+                        "addressLine2": "Oxford",
+                        "addressLine3": "Oxfordshire",
+                        "country": "",
+                        "county": "",
+                        "id": 6,
+                        "postcode": "OX1 1XO",
+                        "town": "",
+                        "type": "Primary"
+                    }
+                ],
+                "companyName": "TrustyLaw.com",
+                "dob": null,
+                "email": "",
+                "firstname": null,
+                "id": 6,
+                "middlenames": null,
+                "salutation": null,
+                "surname": null,
+                "systemStatus": false,
+                "uId": "7000-0000-0096"
             }
         ],
-        "companyName": null,
-        "dob": "1952-07-17",
-        "email": "sally.fathing@opgtest.com",
-        "firstname": "changeme",
-        "id": 1,
-        "middlenames": "Lucille",
-        "salutation": "Mrs",
-        "surname": "changeme",
-        "uId": "7000-0000-0047"
-    },
-    "id": 1,
-    "lifeSustainingTreatment": null,
-    "lpaDonorSignatureDate": "2020-07-15",
-    "onlineLpaId": null,
-    "receiptDate": "2014-09-26",
-    "registrationDate": null,
-    "rejectedDate": null,
-    "replacementAttorneys": [],
-    "status": "Pending",
-    "trustCorporations": [
-        {
-            "addresses": [
-                {
-                    "addressLine1": "170 High Street",
-                    "addressLine2": "Oxford",
-                    "addressLine3": "Oxfordshire",
-                    "country": "",
-                    "county": "",
-                    "id": 6,
-                    "postcode": "OX1 1XO",
-                    "town": "",
-                    "type": "Primary"
-                }
-            ],
-            "companyName": "TrustyLaw.com",
-            "dob": null,
-            "email": "",
-            "firstname": null,
-            "id": 6,
-            "middlenames": null,
-            "salutation": null,
-            "surname": null,
-            "systemStatus": false,
-            "uId": "7000-0000-0096"
-        }
-    ],
-    "uId": "7000-0000-0013"
+        "uId": "7000-0000-0013"
+    }
+  ]
 }

--- a/mock_sirius_backend/api/lpas/mock_data/use_an_lpa_response.json
+++ b/mock_sirius_backend/api/lpas/mock_data/use_an_lpa_response.json
@@ -1,125 +1,814 @@
 {
-    "applicationHasGuidance": false,
-    "applicationHasRestrictions": false,
-    "applicationType": "Classic",
-    "attorneyActDecisions": null,
-    "attorneys": [
+  "results": [
+    {
+      "applicationHasGuidance": false,
+      "applicationHasRestrictions": false,
+      "applicationType": "Classic",
+      "attorneyActDecisions": null,
+      "attorneys": [
         {
-            "addresses": [
-                {
-                    "addressLine1": "25 Cambridge Road",
-                    "addressLine2": "CHATTERIS",
-                    "addressLine3": "",
-                    "country": "",
-                    "county": "",
-                    "id": 7,
-                    "postcode": "PE4 7DH",
-                    "town": "",
-                    "type": "Primary"
-                }
-            ],
-            "companyName": null,
-            "dob": "1972-05-10",
-            "email": "bodge@hotmail.com",
-            "firstname": "Trevor",
-            "id": 7,
-            "middlenames": null,
-            "salutation": "Mr",
-            "surname": "Bodger",
-            "systemStatus": true,
-            "uId": "7000-0000-0104"
-        }
-    ],
-    "cancellationDate": null,
-    "caseAttorneyJointly": false,
-    "caseAttorneyJointlyAndJointlyAndSeverally": false,
-    "caseAttorneyJointlyAndSeverally": true,
-    "caseAttorneySingular": false,
-    "caseSubtype": "pfa",
-    "certificateProviders": [
-        {
-            "addresses": [
-                {
-                    "addressLine1": "32 Jamestown Street",
-                    "addressLine2": "ABLEFIELD",
-                    "addressLine3": "",
-                    "country": "",
-                    "county": "",
-                    "id": 5,
-                    "postcode": "AB2 8KJ",
-                    "town": "",
-                    "type": "Primary"
-                }
-            ],
-            "dob": null,
-            "email": null,
-            "firstname": "Julian",
-            "id": 5,
-            "middlenames": null,
-            "salutation": "Mr",
-            "surname": "Salford",
-            "uId": "7000-0000-0088"
-        }
-    ],
-    "donor": {
-        "addresses": [
+          "addresses": [
             {
-                "addressLine1": "lxzraboqaxnygvbfnbcrdozklqfzpsycwegllkkuubywvvyvjj",
-                "addressLine2": "SOLLINGSBURY",
-                "addressLine3": "",
-                "country": "",
-                "county": "",
-                "id": 1,
-                "postcode": "cytxlxdequ",
-                "town": "",
-                "type": "Primary"
+              "addressLine1": "9 high street",
+              "addressLine2": "",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 9,
+              "postcode": "",
+              "town": "",
+              "type": "Primary"
             }
+          ],
+          "companyName": "",
+          "dob": "1990-05-04",
+          "email": "",
+          "firstname": "jean",
+          "id": 9,
+          "middlenames": "",
+          "salutation": "",
+          "surname": "sanderson",
+          "systemStatus": true,
+          "uId": "7000-0000-0815"
+        },
+        {
+          "addresses": [
+            {
+              "addressLine1": "",
+              "addressLine2": "",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 12,
+              "postcode": "",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": "",
+          "dob": "1975-10-05",
+          "email": "XXXXX",
+          "firstname": "Ann",
+          "id": 12,
+          "middlenames": "",
+          "salutation": "Mrs",
+          "surname": "Summers",
+          "systemStatus": true,
+          "uId": "7000-0000-0849"
+        }
+      ],
+      "cancellationDate": null,
+      "caseAttorneyJointly": false,
+      "caseAttorneyJointlyAndJointlyAndSeverally": false,
+      "caseAttorneyJointlyAndSeverally": true,
+      "caseAttorneySingular": false,
+      "caseSubtype": "hw",
+      "certificateProviders": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "50 Fordham Rd",
+              "addressLine2": "HADFIELD",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 11,
+              "postcode": "SK14 0RH",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "dob": null,
+          "email": null,
+          "firstname": "Danielle",
+          "id": 11,
+          "middlenames": null,
+          "salutation": "Miss",
+          "surname": "Hart ",
+          "uId": "7000-0000-0831"
+        }
+      ],
+      "donor": {
+        "addresses": [
+          {
+            "addressLine1": "81 Front Street",
+            "addressLine2": "LACEBY",
+            "addressLine3": "",
+            "country": "",
+            "county": "",
+            "id": 7,
+            "postcode": "DN37 5SH",
+            "town": "",
+            "type": "Primary"
+          }
         ],
         "companyName": null,
-        "dob": "1952-07-17",
-        "email": "sally.fathing@opgtest.com",
-        "firstname": "changeme",
-        "id": 1,
-        "middlenames": "Lucille",
-        "salutation": "Mrs",
-        "surname": "changeme",
-        "uId": "7000-0000-0047"
+        "dob": "1948-11-01",
+        "email": "RachelSanderson@opgtest.com",
+        "firstname": "Rachel",
+        "id": 7,
+        "linked": [
+          {
+            "id": 7,
+            "uId": "7000-0000-0799"
+          }
+        ],
+        "middlenames": "Emma",
+        "salutation": "Mr",
+        "surname": "Sanderson",
+        "uId": "7000-0000-0799"
+      },
+      "id": 2,
+      "lifeSustainingTreatment": "Option A",
+      "lpaDonorSignatureDate": "2012-12-12",
+      "onlineLpaId": "A33718377316",
+      "receiptDate": "2014-09-26",
+      "registrationDate": "2020-05-14",
+      "rejectedDate": null,
+      "replacementAttorneys": [],
+      "status": "Perfect",
+      "trustCorporations": [],
+      "uId": "7000-0000-0047"
     },
-    "id": 1,
-    "lifeSustainingTreatment": null,
-    "lpaDonorSignatureDate": "2020-07-15",
-    "onlineLpaId": "A33718377316",
-    "receiptDate": "2014-09-26",
-    "registrationDate": null,
-    "rejectedDate": null,
-    "replacementAttorneys": [],
-    "status": "Pending",
-    "trustCorporations": [
+    {
+      "applicationHasGuidance": true,
+      "applicationHasRestrictions": true,
+      "applicationType": "Classic",
+      "attorneyActDecisions": null,
+      "attorneys": [
         {
-            "addresses": [
-                {
-                    "addressLine1": "170 High Street",
-                    "addressLine2": "Oxford",
-                    "addressLine3": "Oxfordshire",
-                    "country": "",
-                    "county": "",
-                    "id": 6,
-                    "postcode": "OX1 1XO",
-                    "town": "",
-                    "type": "Primary"
-                }
-            ],
-            "companyName": "TrustyLaw.com",
-            "dob": null,
-            "email": "",
-            "firstname": null,
-            "id": 6,
-            "middlenames": null,
-            "salutation": null,
-            "surname": null,
-            "systemStatus": false,
-            "uId": "7000-0000-0096"
+          "addresses": [
+            {
+              "addressLine1": "22 Prospect Hill",
+              "addressLine2": "DRONFIELD",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 25,
+              "postcode": "S18 2BY",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": "",
+          "dob": "1975-10-05",
+          "email": "SimonMatthews@opgtest.com",
+          "firstname": "Simon",
+          "id": 25,
+          "middlenames": "",
+          "salutation": "Mr",
+          "surname": "Matthews",
+          "systemStatus": true,
+          "uId": "7000-0000-0997"
+        },
+        {
+          "addresses": [
+            {
+              "addressLine1": "my house",
+              "addressLine2": "",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 2397,
+              "postcode": "",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": "",
+          "dob": "1990-03-17",
+          "email": "",
+          "firstname": "Simone",
+          "id": 2588,
+          "middlenames": "",
+          "salutation": "Miss",
+          "surname": "Matthews",
+          "systemStatus": true,
+          "uId": "7000-0011-6322"
         }
-    ],
-    "uId": "7000-0000-0013"
+      ],
+      "cancellationDate": "2020-03-17",
+      "caseAttorneyJointly": false,
+      "caseAttorneyJointlyAndJointlyAndSeverally": true,
+      "caseAttorneyJointlyAndSeverally": false,
+      "caseAttorneySingular": false,
+      "caseSubtype": "hw",
+      "certificateProviders": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "14 Bootham Crescent",
+              "addressLine2": "RIECHIP",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 27,
+              "postcode": "PH8 1UR",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "dob": null,
+          "email": null,
+          "firstname": "Joanne",
+          "id": 27,
+          "middlenames": null,
+          "salutation": "Mrs",
+          "surname": "Armstrong",
+          "uId": "7000-0000-1011"
+        }
+      ],
+      "donor": {
+        "addresses": [
+          {
+            "addressLine1": "24 Gloucester Road",
+            "addressLine2": "CILLE BHRIGHDE",
+            "addressLine3": "",
+            "country": "",
+            "county": "",
+            "id": 23,
+            "postcode": "HS8 2YB",
+            "town": "",
+            "type": "Primary"
+          }
+        ],
+        "companyName": null,
+        "dob": "1948-11-01",
+        "email": "babaragilson@opgtest.com",
+        "firstname": "Babara",
+        "id": 23,
+        "linked": [
+          {
+            "id": 23,
+            "uId": "7000-0000-0971"
+          }
+        ],
+        "middlenames": "Suzanne",
+        "salutation": "Mrs",
+        "surname": "Gilson",
+        "uId": "7000-0000-0971"
+      },
+      "id": 5,
+      "lifeSustainingTreatment": "Option B",
+      "lpaDonorSignatureDate": "2019-10-03",
+      "onlineLpaId": "A15527329531",
+      "receiptDate": "2014-09-26",
+      "registrationDate": "2020-05-15",
+      "rejectedDate": null,
+      "replacementAttorneys": [],
+      "status": "Registered",
+      "trustCorporations": [],
+      "uId": "7000-0000-0138"
+    },
+    {
+      "applicationHasGuidance": true,
+      "applicationHasRestrictions": false,
+      "applicationType": "Classic",
+      "attorneyActDecisions": null,
+      "attorneys": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "29 Wressle Road",
+              "addressLine2": "PLUSH",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 45,
+              "postcode": "DT2 2SH",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": "",
+          "dob": "1975-10-05",
+          "email": "TainaRucker@opgtest.com",
+          "firstname": "Taina",
+          "id": 45,
+          "middlenames": "",
+          "salutation": "Mr",
+          "surname": "Rucker",
+          "systemStatus": false,
+          "uId": "7000-0000-1235"
+        }
+      ],
+      "cancellationDate": "2020-02-03",
+      "caseAttorneyJointly": false,
+      "caseAttorneyJointlyAndJointlyAndSeverally": false,
+      "caseAttorneyJointlyAndSeverally": true,
+      "caseAttorneySingular": false,
+      "caseSubtype": "pfa",
+      "certificateProviders": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "65 Moulton Road",
+              "addressLine2": "GUY'S MARSH",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 47,
+              "postcode": "SP7 1RD",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "dob": null,
+          "email": null,
+          "firstname": "Desire",
+          "id": 47,
+          "middlenames": null,
+          "salutation": "Miss",
+          "surname": "Beasley",
+          "uId": "7000-0000-1250"
+        }
+      ],
+      "donor": {
+        "addresses": [
+          {
+            "addressLine1": "26 Traill Street",
+            "addressLine2": "ROSE GREEN",
+            "addressLine3": "",
+            "country": "",
+            "county": "",
+            "id": 43,
+            "postcode": "CO6 2XT",
+            "town": "",
+            "type": "Primary"
+          }
+        ],
+        "companyName": null,
+        "dob": "1948-11-01",
+        "email": "orethalang@opgtest.com",
+        "firstname": "Oretha",
+        "id": 43,
+        "linked": [
+          {
+            "id": 43,
+            "uId": "7000-0000-1219"
+          }
+        ],
+        "middlenames": "Veronica",
+        "salutation": "Mr",
+        "surname": "Lang",
+        "uId": "7000-0000-1219"
+      },
+      "id": 9,
+      "lifeSustainingTreatment": "Option B",
+      "lpaDonorSignatureDate": "2019-10-05",
+      "onlineLpaId": "A48218451245",
+      "receiptDate": "2014-09-26",
+      "registrationDate": null,
+      "rejectedDate": null,
+      "replacementAttorneys": [],
+      "status": "Cancelled",
+      "trustCorporations": [],
+      "uId": "7000-0000-0252"
+    },
+    {
+      "applicationHasGuidance": false,
+      "applicationHasRestrictions": false,
+      "applicationType": "Classic",
+      "attorneyActDecisions": null,
+      "attorneys": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "50 Hull Road",
+              "addressLine2": "PAR",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 64,
+              "postcode": "PL24 9DQ",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": null,
+          "dob": "1975-10-05",
+          "email": "SimonMatthews@opgtest.com",
+          "firstname": "Simon",
+          "id": 64,
+          "middlenames": null,
+          "salutation": "Mr",
+          "surname": "Matthews",
+          "systemStatus": true,
+          "uId": "7000-0000-1441"
+        },
+        {
+          "addresses": [
+            {
+              "addressLine1": "1 Use Lane",
+              "addressLine2": "",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 2808,
+              "postcode": "",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": null,
+          "dob": "1975-10-05",
+          "email": null,
+          "firstname": "simone",
+          "id": 3022,
+          "middlenames": null,
+          "salutation": "miss",
+          "surname": "matthews",
+          "systemStatus": true,
+          "uId": "7000-0013-6098"
+        }
+      ],
+      "cancellationDate": null,
+      "caseAttorneyJointly": false,
+      "caseAttorneyJointlyAndJointlyAndSeverally": false,
+      "caseAttorneyJointlyAndSeverally": true,
+      "caseAttorneySingular": false,
+      "caseSubtype": "pfa",
+      "certificateProviders": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "69 Felix Lane",
+              "addressLine2": "SHUSTOKE",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 63,
+              "postcode": "B46 7EY",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "dob": null,
+          "email": null,
+          "firstname": "David",
+          "id": 63,
+          "middlenames": null,
+          "salutation": "Mr",
+          "surname": "Stewart",
+          "uId": "7000-0000-1433"
+        }
+      ],
+      "donor": {
+        "addresses": [
+          {
+            "addressLine1": "73 Withers Close",
+            "addressLine2": "ALLATHASDAL",
+            "addressLine3": "",
+            "country": "",
+            "county": "",
+            "id": 59,
+            "postcode": "HS9 2PN",
+            "town": "",
+            "type": "Primary"
+          }
+        ],
+        "companyName": null,
+        "dob": "1948-11-01",
+        "email": "linkedpersonone@opgtest.com",
+        "firstname": "Linked",
+        "id": 59,
+        "linked": [
+          {
+            "id": 59,
+            "uId": "7000-0000-1391"
+          }
+        ],
+        "middlenames": "Person",
+        "salutation": "Mr",
+        "surname": "One",
+        "uId": "7000-0000-1391"
+      },
+      "id": 12,
+      "lifeSustainingTreatment": "Option A",
+      "lpaDonorSignatureDate": "2019-10-06",
+      "onlineLpaId": null,
+      "receiptDate": "2014-09-26",
+      "registrationDate": "2020-06-10",
+      "rejectedDate": null,
+      "replacementAttorneys": [],
+      "status": "Registered",
+      "trustCorporations": [],
+      "uId": "7000-0000-0344"
+    },
+    {
+      "applicationHasGuidance": false,
+      "applicationHasRestrictions": false,
+      "applicationType": "Classic",
+      "attorneyActDecisions": null,
+      "attorneys": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "13 Union Terrace",
+              "addressLine2": "LOGIE PERT",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 78,
+              "postcode": "DD10 4TB",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": null,
+          "dob": "1975-10-05",
+          "email": "AndreaRobinson@opgtest.com",
+          "firstname": "Andrea",
+          "id": 78,
+          "middlenames": null,
+          "salutation": "Mrs",
+          "surname": "Robinson",
+          "systemStatus": true,
+          "uId": "7000-0000-1599"
+        }
+      ],
+      "cancellationDate": null,
+      "caseAttorneyJointly": false,
+      "caseAttorneyJointlyAndJointlyAndSeverally": false,
+      "caseAttorneyJointlyAndSeverally": true,
+      "caseAttorneySingular": false,
+      "caseSubtype": "pfa",
+      "certificateProviders": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "81 Front Street",
+              "addressLine2": "LACEBY",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 80,
+              "postcode": "DN37 5SH",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "dob": null,
+          "email": null,
+          "firstname": "Rachel",
+          "id": 80,
+          "middlenames": null,
+          "salutation": "Mrs",
+          "surname": "Sanderson",
+          "uId": "7000-0000-1615"
+        }
+      ],
+      "donor": {
+        "addresses": [
+          {
+            "addressLine1": "16 Wade Lane",
+            "addressLine2": "SALTWICK",
+            "addressLine3": "",
+            "country": "",
+            "county": "",
+            "id": 76,
+            "postcode": "NE20 3PN",
+            "town": "",
+            "type": "Primary"
+          }
+        ],
+        "companyName": null,
+        "dob": "1948-11-01",
+        "email": "demtriceflood@opgtest.com",
+        "firstname": "Demetrice",
+        "id": 76,
+        "linked": [
+          {
+            "id": 76,
+            "uId": "7000-0000-1573"
+          }
+        ],
+        "middlenames": "Ophelia",
+        "salutation": "Mrs",
+        "surname": "Flood",
+        "uId": "7000-0000-1573"
+      },
+      "id": 15,
+      "lifeSustainingTreatment": null,
+      "lpaDonorSignatureDate": "2019-10-02",
+      "onlineLpaId": "A26997335988",
+      "receiptDate": "2014-09-26",
+      "registrationDate": null,
+      "rejectedDate": null,
+      "replacementAttorneys": [],
+      "status": "Pending",
+      "trustCorporations": [],
+      "uId": "7000-0000-0435"
+    },
+    {
+      "applicationHasGuidance": false,
+      "applicationHasRestrictions": false,
+      "applicationType": "Classic",
+      "attorneyActDecisions": null,
+      "attorneys": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "50 Hull Road",
+              "addressLine2": "PAR",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 97,
+              "postcode": "PL24 9DQ",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": null,
+          "dob": "1975-10-05",
+          "email": "SimonMatthews@opgtest.com",
+          "firstname": "Simon",
+          "id": 97,
+          "middlenames": null,
+          "salutation": "Mr",
+          "surname": "Matthews",
+          "systemStatus": true,
+          "uId": "7000-0000-1805"
+        }
+      ],
+      "cancellationDate": null,
+      "caseAttorneyJointly": false,
+      "caseAttorneyJointlyAndJointlyAndSeverally": true,
+      "caseAttorneyJointlyAndSeverally": false,
+      "caseAttorneySingular": false,
+      "caseSubtype": "pfa",
+      "certificateProviders": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "69 Felix Lane",
+              "addressLine2": "SHUSTOKE",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 96,
+              "postcode": "B46 7EY",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "dob": null,
+          "email": null,
+          "firstname": "David",
+          "id": 96,
+          "middlenames": null,
+          "salutation": "Mr",
+          "surname": "Stewart",
+          "uId": "7000-0000-1797"
+        }
+      ],
+      "donor": {
+        "addresses": [
+          {
+            "addressLine1": "71 Withers Close",
+            "addressLine2": "ALLATHASDAL",
+            "addressLine3": "",
+            "country": "",
+            "county": "",
+            "id": 92,
+            "postcode": "HS9 2PN",
+            "town": "",
+            "type": "Primary"
+          }
+        ],
+        "companyName": null,
+        "dob": "1948-11-01",
+        "email": "cherrylschindler@opgtest.com",
+        "firstname": "Cherryl",
+        "id": 92,
+        "linked": [
+          {
+            "id": 92,
+            "uId": "7000-0000-1755"
+          }
+        ],
+        "middlenames": "Marie",
+        "salutation": "Ms",
+        "surname": "Schindler",
+        "uId": "7000-0000-1755"
+      },
+      "id": 18,
+      "lifeSustainingTreatment": "Option A",
+      "lpaDonorSignatureDate": "2012-12-12",
+      "onlineLpaId": "A13316443118",
+      "receiptDate": "2014-09-26",
+      "registrationDate": null,
+      "rejectedDate": null,
+      "replacementAttorneys": [],
+      "status": "Pending",
+      "trustCorporations": [],
+      "uId": "7000-0000-0526"
+    },
+    {
+      "applicationHasGuidance": false,
+      "applicationHasRestrictions": false,
+      "applicationType": "Classic",
+      "attorneyActDecisions": null,
+      "attorneys": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "50 Hull Road",
+              "addressLine2": "PAR",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 115,
+              "postcode": "PL24 9DQ",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "companyName": null,
+          "dob": "1975-10-05",
+          "email": "SimonMatthews@opgtest.com",
+          "firstname": "Simon",
+          "id": 115,
+          "middlenames": null,
+          "salutation": "Mr",
+          "surname": "Matthews",
+          "systemStatus": true,
+          "uId": "7000-0000-1987"
+        }
+      ],
+      "cancellationDate": null,
+      "caseAttorneyJointly": false,
+      "caseAttorneyJointlyAndJointlyAndSeverally": false,
+      "caseAttorneyJointlyAndSeverally": true,
+      "caseAttorneySingular": false,
+      "caseSubtype": "pfa",
+      "certificateProviders": [
+        {
+          "addresses": [
+            {
+              "addressLine1": "69 Felix Lane",
+              "addressLine2": "SHUSTOKE",
+              "addressLine3": "",
+              "country": "",
+              "county": "",
+              "id": 114,
+              "postcode": "B46 7EY",
+              "town": "",
+              "type": "Primary"
+            }
+          ],
+          "dob": null,
+          "email": null,
+          "firstname": "David",
+          "id": 114,
+          "middlenames": null,
+          "salutation": "Mr",
+          "surname": "Stewart",
+          "uId": "7000-0000-1979"
+        }
+      ],
+      "donor": {
+        "addresses": [
+          {
+            "addressLine1": "71 Withers Close",
+            "addressLine2": "ALLATHASDAL",
+            "addressLine3": "",
+            "country": "",
+            "county": "",
+            "id": 110,
+            "postcode": "HS9 2PN",
+            "town": "",
+            "type": "Primary"
+          }
+        ],
+        "companyName": null,
+        "dob": "1948-11-01",
+        "email": "linkedpersonone@opgtest.com",
+        "firstname": "Linked",
+        "id": 110,
+        "linked": [
+          {
+            "id": 110,
+            "uId": "7000-0000-1938"
+          }
+        ],
+        "middlenames": "Person",
+        "salutation": "Mr",
+        "surname": "one",
+        "uId": "7000-0000-1938"
+      },
+      "id": 21,
+      "lifeSustainingTreatment": null,
+      "lpaDonorSignatureDate": "2019-09-28",
+      "onlineLpaId": null,
+      "receiptDate": "2014-09-26",
+      "registrationDate": null,
+      "rejectedDate": null,
+      "replacementAttorneys": [],
+      "status": "Pending",
+      "trustCorporations": [],
+      "uId": "7000-0000-0617"
+    }
+  ]
 }


### PR DESCRIPTION
## Purpose

Use opg-data-lpa with UaL locally.

## Approach

**Docker-Compose**

- Use an override file to set the default port values for api-gateway (4343:4343). Override files are read by default when running a docker-compose command (along with docker-compose.yml) without specifying a file to read (-f).
- Use a docker-compose.bridge-ual to configure available ports (4242:4343) and networks (opg-use-an-lpa_lpas-collection) to connect UaL and api-gateway.

**Makefile**

- Add new targets to bring up api-gateway configured to talk to UaL.
- Remove `-f docker-compose.yml` where it is the only file specified. This is to allow both docker-compose.yml and docker-compose.override.yml to be read and merged by default.

**Mock Sirius Public API Handler**

- Modify the handler so that it can find and serve an LPA case from a file of LPA cases. This is to allow lpas-collection to be used as a mock to develop against locally.
- Add new JSON data with many cases for UaL and a structure to follow for Make.

## Learning

https://docs.docker.com/compose/extends/#multiple-compose-files

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
