### PR TITLE
VEGA-658: Add extra LPA date fields to Online LPA tool responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ is a bit more of an in depth set up process required.
    aws-vault exec sirius-dev -- aws codeartifact login --tool pip --repository opg-pip-shared-code-dev --domain opg-moj --domain-owner 288342028542 --region eu-west-1
    ```
 
+   * Copy the output `export` statements into your shell to set AWS_* environment variables
+
    * Install the dev requirements
    ```bash
    pip3 install -r lambda_functions/v1/requirements/dev-requirements.txt

--- a/integration_tests/v1/response_schemas/lpa_online_tool_schema.json
+++ b/integration_tests/v1/response_schemas/lpa_online_tool_schema.json
@@ -3,10 +3,10 @@
   "type": "object",
   "properties": {
     "cancellationDate": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "invalidDate": {
-      "type": "string"
+      "type": ["string", "null"]
     },
     "onlineLpaId": {
       "type": "string"
@@ -24,7 +24,7 @@
       "type": "string"
     },
     "withdrawnDate": {
-      "type": "string"
+      "type": ["string", "null"]
     }
   },
   "required": [

--- a/integration_tests/v1/response_schemas/lpa_online_tool_schema.json
+++ b/integration_tests/v1/response_schemas/lpa_online_tool_schema.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
+    "cancellationDate": {
+      "type": "string"
+    },
+    "invalidDate": {
+      "type": "string"
+    },
     "onlineLpaId": {
       "type": "string"
     },
@@ -16,13 +22,18 @@
     },
     "status": {
       "type": "string"
+    },
+    "withdrawnDate": {
+      "type": "string"
     }
   },
   "required": [
+    "invalidDate",
     "onlineLpaId",
     "receiptDate",
     "registrationDate",
     "rejectedDate",
-    "status"
+    "status",
+    "withdrawnDate"
   ]
 }

--- a/lambda_functions/v1/functions/lpa/app/api/sirius_helpers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/sirius_helpers.py
@@ -31,11 +31,14 @@ def format_online_tool_response(sirius_response):
     lpa_data = sirius_response[0]
 
     result = {
+        "cancellationDate": lpa_data["cancellationDate"],
+        "invalidDate": lpa_data["invalidDate"],
         "onlineLpaId": lpa_data["onlineLpaId"],
         "receiptDate": lpa_data["receiptDate"],
         "registrationDate": lpa_data["registrationDate"],
         "rejectedDate": lpa_data["rejectedDate"],
         "status": lpa_data["status"],
+        "withdrawnDate": lpa_data["withdrawnDate"],
     }
 
     return result

--- a/lambda_functions/v1/openapi/lpa-openapi.yml
+++ b/lambda_functions/v1/openapi/lpa-openapi.yml
@@ -203,12 +203,27 @@ paths:
               schema:
                 type: object
                 required:
+                  - cancellationDate
+                  - invalidDate
                   - onlineLpaId
                   - receiptDate
                   - registrationDate
                   - rejectedDate
                   - status
+                  - withdrawnDate
                 properties:
+                  cancellationDate:
+                    type: string
+                    format: date
+                    nullable: true
+                    description: The date the LPA was registered
+                    example: '2018-06-30'
+                  invalidDate:
+                    type: string
+                    format: date
+                    nullable: true
+                    description: The date the LPA was registered
+                    example: '2018-06-30'
                   onlineLpaId:
                     type: string
                     example: A22486562341
@@ -225,6 +240,12 @@ paths:
                     description: The date the LPA was rejected
                     example: '2018-06-30'
                   registrationDate:
+                    type: string
+                    format: date
+                    nullable: true
+                    description: The date the LPA was registered
+                    example: '2018-06-30'
+                  withdrawnDate:
                     type: string
                     format: date
                     nullable: true
@@ -287,11 +308,14 @@ paths:
               schema:
                 type: object
                 required:
+                  - cancellationDate
+                  - invalidDate
                   - onlineLpaId
                   - receiptDate
                   - registrationDate
                   - rejectedDate
                   - status
+                  - withdrawnDate
                 properties:
                   onlineLpaId:
                     type: string

--- a/lambda_functions/v1/tests/test_data/lpa_online_tool_response.json
+++ b/lambda_functions/v1/tests/test_data/lpa_online_tool_response.json
@@ -1,7 +1,10 @@
 {
+    "cancellationDate": null,
+    "invalidDate": null,
     "onlineLpaId": "A39721583862",
     "receiptDate": "2017-04-11",
     "registrationDate": null,
     "rejectedDate": null,
-    "status": "Pending"
+    "status": "Pending",
+    "withdrawnDate": null
 }

--- a/mock_aws_services/Dockerfile
+++ b/mock_aws_services/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:alpine
 
-RUN apk add --no-cache gcc musl-dev libffi-dev openssl-dev && \
+RUN apk add --no-cache gcc rust cargo musl-dev libffi-dev openssl-dev && \
     pip install moto[server] && \
-    apk del gcc musl-dev libffi-dev openssl-dev
+    apk del gcc rust cargo musl-dev libffi-dev openssl-dev
 
 
 CMD moto_server secretsmanager -H 0.0.0.0 -p 4566

--- a/mock_sirius_backend/api/lpas/mock_data/lpa_online_tool_response.json
+++ b/mock_sirius_backend/api/lpas/mock_data/lpa_online_tool_response.json
@@ -88,6 +88,7 @@
             "uId": "7000-0000-0047"
         },
         "id": 1,
+        "invalidDate": null,
         "lifeSustainingTreatment": null,
         "lpaDonorSignatureDate": "2020-07-15",
         "onlineLpaId": "A39721583862",
@@ -123,7 +124,8 @@
                 "uId": "7000-0000-0096"
             }
         ],
-        "uId": "7000-0000-0013"
+        "uId": "7000-0000-0013",
+        "withdrawnDate": null
     }
   ]
 }

--- a/mock_sirius_backend/sirius_public_api.yaml
+++ b/mock_sirius_backend/sirius_public_api.yaml
@@ -290,6 +290,8 @@ definitions:
       - rejectedDate
       - registrationDate
       - cancellationDate
+      - invalidDate
+      - withdrawnDate
       - status
       - caseAttorneySingular
       - caseAttorneyJointlyAndSeverally
@@ -340,6 +342,16 @@ definitions:
         type: string
         format: date
         description: The date the LPA was cancelled
+        example: '2018-06-30'
+      invalidDate:
+        type: string
+        format: date
+        description: The date the LPA was marked invalid
+        example: '2018-06-30'
+      withdrawnDate:
+        type: string
+        format: date
+        description: The date the LPA was withdrawn
         example: '2018-06-30'
       status:
         type: string


### PR DESCRIPTION
## Purpose

The Online LPA Tool wants to show further details to correspondents about their LPA. To do so, they need access to some additional date fields from the Public API. Specifically, `cancellationDate`, `invalidDate` and `withdrawnDate`.

These fields have already been [added to Sirius](https://github.com/ministryofjustice/opg-sirius/pull/4352) and [the old API gateway](https://github.com/ministryofjustice/opg-sirius-api-gateway/pull/84/files) which the Online LPA tool is still using. Adding the fields here will provide an easier transition to the new API gateway when the team is ready.

## Approach

I added the fields to the mock Sirius backend so they were available in tests, then added them to the `format_online_tool_response` helper function. I also updated the OpenAPI spec and the test schema/data.

This PR also includes [Seema's PR](https://github.com/ministryofjustice/opg-data-lpa/pull/32) because it's necessary to run Rust and Cargo to stand up the application, and an update to the README to clarify how to set up the local environment.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
 * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
  * I've expanded the current test data to include the new fields
* [x] I have run the integration tests (results below)
  * "41 passed, 6 warnings in 6.50s". The warnings are due to `charset` being deprecated in favour of `encoding`
