### PR TITLE
IN-654 up elasticache clusters to be inline with sirius availability …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,8 +123,8 @@ orbs:
           TF_CLI_ARGS_destroy: -input=false -auto-approve
           TF_CLI_ARGS_init: -input=false -upgrade=true -reconfigure
           TF_VAR_default_role: sirius-ci
-          TF_VERSION: 0.12.26
-          TF_SHA256SUM: 607bc802b1c6c2a5e62cc48640f38aaa64bef1501b46f0ae4829feb51594b257
+          TF_VERSION: 0.13.5
+          TF_SHA256SUM: f7b7a7b1bfbf5d78151cfe3d1d463140b5fd6a354e71a7de2b5644e652ca5147 # pragma: allowlist secret
       python:
         docker:
           - image: circleci/python:3.8.1

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-12-08T13:12:21Z",
+  "generated_at": "2021-04-06T15:56:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -46,14 +46,6 @@
     }
   ],
   "results": {
-    ".circleci/config.yml": [
-      {
-        "hashed_secret": "9471c0494b91aec2cb3db5be98b1a210cb001966",
-        "is_verified": false,
-        "line_number": 127,
-        "type": "Hex High Entropy String"
-      }
-    ],
     "docker-compose.yml": [
       {
         "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",

--- a/docs/support_scripts/load_testing/load_testing.go
+++ b/docs/support_scripts/load_testing/load_testing.go
@@ -90,9 +90,9 @@ func getFilePath(urlSuffix string) string {
 }
 
 func main() {
-	baseUrl := flag.String("base_url", "api.dev.sirius.opg.digital/v1", "a string")
+	baseUrl := flag.String("base_url", "dev.lpa.api.opg.service.justice.gov.uk/v1", "a string")
 	urlSuffix := flag.String("url_suffix", "lpa-online-tool/lpas", "a string")
-	batchSize := flag.Int("batch_size", 5, "an int")
+	batchSize := flag.Int("batch_size", 1, "an int")
 	numberOfBatches := flag.Int("number_of_batches", 2, "an int")
 	waitBetweenBatches := flag.Int("wait_between_batches", 2, "an int")
 	flag.Parse()

--- a/docs/support_scripts/requests/api_request.go
+++ b/docs/support_scripts/requests/api_request.go
@@ -26,7 +26,7 @@ func main() {
 
 	flag.Parse()
 
-  roleToAssume := "arn:aws:iam::" + *account + ":role/" + *role
+    roleToAssume := "arn:aws:iam::" + *account + ":role/" + *role
 
 	var url string = ""
 

--- a/terraform/environment/elasticache.tf
+++ b/terraform/environment/elasticache.tf
@@ -1,3 +1,6 @@
+data "aws_availability_zones" "available" {
+}
+
 resource "aws_elasticache_replication_group" "lpa_redis" {
   automatic_failover_enabled    = local.account.elasticache_count == 1 ? false : true
   engine                        = "redis"
@@ -5,6 +8,8 @@ resource "aws_elasticache_replication_group" "lpa_redis" {
   replication_group_id          = "lpa-data-redis-${local.environment}"
   replication_group_description = "Replication Group for LPA Data"
   node_type                     = "cache.t2.small"
+  multi_az_enabled              = local.account.elasticache_count == 1 ? false : true
+  availability_zones            = data.aws_availability_zones.available.zone_ids
   number_cache_clusters         = local.account.elasticache_count
   parameter_group_name          = "default.redis5.0"
   port                          = 6379

--- a/terraform/environment/elasticache.tf
+++ b/terraform/environment/elasticache.tf
@@ -9,7 +9,7 @@ resource "aws_elasticache_replication_group" "lpa_redis" {
   replication_group_description = "Replication Group for LPA Data"
   node_type                     = "cache.t2.small"
   multi_az_enabled              = local.account.elasticache_count == 1 ? false : true
-  availability_zones            = data.aws_availability_zones.available.zone_ids
+  availability_zones            = local.account.elasticache_count == 1 ? ["eu-west-1a"] : data.aws_availability_zones.available.names
   number_cache_clusters         = local.account.elasticache_count
   parameter_group_name          = "default.redis5.0"
   port                          = 6379
@@ -17,10 +17,6 @@ resource "aws_elasticache_replication_group" "lpa_redis" {
   security_group_ids            = [aws_security_group.lpa_redis_sg.id]
   tags                          = local.default_tags
   apply_immediately             = true
-
-  lifecycle {
-    ignore_changes = [number_cache_clusters]
-  }
 }
 
 resource "aws_security_group" "lpa_redis_sg" {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -32,7 +32,7 @@
       "vpc_id": "vpc-037acd53d9ce813b4",
       "logger_level": "INFO",
       "threshold": 10,
-      "elasticache_count": 1
+      "elasticache_count": 3
     },
     "production": {
       "account_id": "649098267436",
@@ -48,7 +48,7 @@
       "vpc_id": "vpc-6809cc0f",
       "logger_level": "INFO",
       "threshold": 1,
-      "elasticache_count": 2
+      "elasticache_count": 3
     }
   }
 }


### PR DESCRIPTION
## Purpose

It has been requested that all sirius related infra be truly multi az. Making elasticache multi AZ 

## Approach

These changes are very destructive in terms of elasticache cluster. However I have tested running load tests against the env whilst making the changes and it comes back fine so as long as sirius isn't down whilst we are replacing this then we should be ok.

## Learning

NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
