### PR TITLE
LPAL-377 add preprod make an LPA account to dev.

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -7,7 +7,8 @@
         "\"arn:aws:iam::001780581745:root\"",
         "\"arn:aws:iam::050256574573:root\"",
         "\"arn:aws:iam::367815980639:root\"",
-        "\"arn:aws:iam::888228022356:root\""
+        "\"arn:aws:iam::888228022356:root\"",
+        "\"arn:aws:iam::987830934591:role/preproduction-api-task-role\""
       ],
       "is_production": "false",
       "opg_hosted_zone": "dev.lpa.api.opg.service.justice.gov.uk",


### PR DESCRIPTION
## Purpose

To Add Preprod account on LPA Live (make) an LPA to the dev domain, which houses the integrations environment.

fixes https://opgtransform.atlassian.net/browse/LPAL-377


## Approach

Add specific role for make an LPA to access the dev domain, in tfvars.json

## Learning
N/A
## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
