### PR TITLE
LPAL-315 change preprod access to root

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -8,7 +8,7 @@
         "\"arn:aws:iam::050256574573:root\"",
         "\"arn:aws:iam::367815980639:root\"",
         "\"arn:aws:iam::888228022356:root\"",
-        "\"arn:aws:iam::987830934591:role/preproduction-api-task-role\""
+        "\"arn:aws:iam::987830934591:root\""
       ],
       "is_production": "false",
       "opg_hosted_zone": "dev.lpa.api.opg.service.justice.gov.uk",


### PR DESCRIPTION
## Purpose

switching on root access for LPA Live preprod for the gateway. this should theoretically allow access to integrations from there.

## Approach

update `terraform.tfvars.json` 

## Learning

for some reason `preproduction-api-task-role` doesn't seem to be allowed to run, returning 403's on this service. we'll switch to `root` instead to see if that works.

## Checklist

* [X] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
