### PR TITLE
UML-1562: Support 200 responses from requestCode endpoint

### DIFF
--- a/lambda_functions/v1/functions/lpa/app/api/handlers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/handlers.py
@@ -70,7 +70,7 @@ def request_code(body):
         content_type="application/json",
         data=json.dumps(body) if isinstance(body, dict) else body
     )
-    if sirius_status_code != 204:
+    if sirius_status_code != 204 and sirius_status_code != 200:
         logger.error(f"Sirius error: {sirius_status_code}")
 
     return sirius_response, sirius_status_code

--- a/lambda_functions/v1/openapi/lpa-openapi.yml
+++ b/lambda_functions/v1/openapi/lpa-openapi.yml
@@ -397,13 +397,24 @@ paths:
               type: object
               required:
                 - case_uid
-                - actor_uid
               properties:
-                actor_uid:
-                  type: integer
                 case_uid:
                   type: integer
+                actor_uid:
+                  type: integer
+                notes:
+                  type: string
       responses:
+        '200':
+          description: Letter was successfully enqueued or cleanse process started
+          schema:
+            type: object
+            required:
+              - queuedForCleansing
+            properties:
+              queuedForCleansing:
+                type: boolean
+                description: Whether the request was queued for cleansing
         '204':
           description: Letter was successfully enqueued
         '400':

--- a/lambda_functions/v1/openapi/lpa-openapi.yml
+++ b/lambda_functions/v1/openapi/lpa-openapi.yml
@@ -277,6 +277,8 @@ paths:
           description: The Sirius data provider timed out
   /use-an-lpa/lpas/{lpa_online_tool_id}:
     get:
+      tags:
+        - "use-a-lpa"
       security:
         - sigv4: []
       x-amazon-apigateway-request-validator: "all"
@@ -377,6 +379,8 @@ paths:
           description: The Sirius data provider timed out
   /use-an-lpa/lpas/requestCode:
     post:
+      tags:
+        - "use-a-lpa"
       security:
         - sigv4: []
       x-amazon-apigateway-request-validator: "all"
@@ -393,17 +397,21 @@ paths:
         required: true
         content:
           application/json:
-            schema:
-              type: object
-              required:
-                - case_uid
-              properties:
-                case_uid:
-                  type: integer
-                actor_uid:
-                  type: integer
-                notes:
-                  type: string
+            schema: 
+              oneOf:
+                - $ref: "#/components/schemas/LetterRequest"
+                - $ref: "#/components/schemas/LetterRequestWithCleanse"
+            examples:
+              request:
+                summary: as letter request
+                value:
+                  case_uid: 700000000000
+                  actor_uid: 700000000000
+              cleanse:
+                summary: as cleanse request
+                value:
+                  case_uid: 700000000000
+                  notes: "Name: Example\nPostcode: EX4 MPL\nEmail: example@example.org"
       responses:
         '200':
           description: Letter was successfully enqueued or cleanse process started
@@ -421,6 +429,7 @@ paths:
           description: Invalid request
         '500':
           description: Unexpected error
+          
 components:
   securitySchemes:
     sigv4:
@@ -441,6 +450,27 @@ components:
         cache-status:
           type: string
           example: "OK"
+    LetterRequest:
+      type: object
+      required:
+        - case_uid
+        - actor_uid
+      properties:
+        actor_uid:
+          type: integer
+        case_uid:
+          type: integer
+    LetterRequestWithCleanse:
+      type: object
+      required:
+        - case_uid
+        - notes
+      properties:
+        notes:
+          type: string
+          maxLength: 1000
+        case_uid:
+          type: integer      
     Error400:
       type: object
       required:

--- a/mock_sirius_backend/api/lpas/handlers.py
+++ b/mock_sirius_backend/api/lpas/handlers.py
@@ -66,7 +66,7 @@ def handle_lpa_get(query_params):
             return 404, ""
 
 
-def handle_request_letter(caseUid, actorUid):
+def handle_request_letter(caseUid, actorUid, notes):
 
     response_data = load_data(
         parent_folder="lpas", filename="use_an_lpa_response.json", as_json=False
@@ -78,6 +78,9 @@ def handle_request_letter(caseUid, actorUid):
     for result in response_data["results"]:
         if result["uId"] in case_id:
 
+            if notes != None:
+                return 200, "{\"queuedForCleansing\":true}"
+
             if result['donor']['uId'] == actor_id:
                 return 204, "{}"
 
@@ -86,4 +89,3 @@ def handle_request_letter(caseUid, actorUid):
                     return 204, "{}"
 
     return 400, "{}"
-    

--- a/mock_sirius_backend/app.py
+++ b/mock_sirius_backend/app.py
@@ -21,7 +21,11 @@ def getLpas(*args, **kwargs):
 
 
 def requestCode(request):
-    status_code, response_message = handle_request_letter(caseUid=request['case_uid'], actorUid=request['actor_uid'])
+    status_code, response_message = handle_request_letter(
+        caseUid=request.get('case_uid', None),
+        actorUid=request.get('actor_uid', None),
+        notes=request.get('notes', None)
+    )
     logging.info(f"status_code: {status_code}")
     logging.info(f"response_message: {response_message}")
 

--- a/mock_sirius_backend/sirius_public_api.yaml
+++ b/mock_sirius_backend/sirius_public_api.yaml
@@ -65,13 +65,24 @@ paths:
             type: object
             required:
               - case_uid
-              - actor_uid
             properties:
-              actor_uid:
-                type: integer
               case_uid:
                 type: integer
+              actor_uid:
+                type: integer
+              notes:
+                type: string
       responses:
+        '200':
+          description: Letter was successfully enqueued or cleanse process started
+          schema:
+            type: object
+            required:
+              - queuedForCleansing
+            properties:
+              queuedForCleansing:
+                type: boolean
+                description: Whether the request was queued for cleansing
         '204':
           description: Letter was successfully enqueued
           schema:


### PR DESCRIPTION
## Purpose

The `requestCode` endpoint can return either a 200 or 204 response on success

## Approach

Update the API handler and OpenAPI definitions to support 200 responses, and update the mock to mimic Sirius's behaviour.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
  * Not yet, I can't get them working
