### PR TITLE
Return json when given letter request with notes rather than a string

### DIFF
--- a/mock_sirius_backend/api/lpas/handlers.py
+++ b/mock_sirius_backend/api/lpas/handlers.py
@@ -2,6 +2,7 @@ from ..utilities import load_data
 
 from textwrap import wrap
 
+import json
 
 def handle_lpa_get(query_params):
 
@@ -79,7 +80,7 @@ def handle_request_letter(caseUid, actorUid, notes):
         if result["uId"] in case_id:
 
             if notes != None:
-                return 200, "{\"queuedForCleansing\":true}"
+                return 200, json.loads('{"queuedForCleansing":true}')
 
             if result['donor']['uId'] == actor_id:
                 return 204, "{}"


### PR DESCRIPTION
## Purpose

Currently the mock has {"queuedForCleansing":true} as a string embedded inside a JSON rather than a just a single nested JSON.

## Approach

Currently I have being decoding the json twice inside the ULPA code however when attaching to the integration version of Sirius it broke since the actual implementation has the expected nested json and didn't understand being decoded twice.

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [x] I have run the integration tests (results below)
