### PR TITLE
Add statusDate to Public API

### DIFF
--- a/integration_tests/v1/response_schemas/lpa_online_tool_schema.json
+++ b/integration_tests/v1/response_schemas/lpa_online_tool_schema.json
@@ -26,6 +26,9 @@
     "status": {
       "type": "string"
     },
+    "statusDate": {
+      "type": ["string", "null"]
+    },
     "withdrawnDate": {
       "type": ["string", "null"]
     }
@@ -38,6 +41,7 @@
     "registrationDate",
     "rejectedDate",
     "status",
+    "statusDate",
     "withdrawnDate"
   ]
 }

--- a/lambda_functions/v1/functions/lpa/app/api/sirius_helpers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/sirius_helpers.py
@@ -39,6 +39,7 @@ def format_online_tool_response(sirius_response):
         "registrationDate": lpa_data["registrationDate"],
         "rejectedDate": lpa_data["rejectedDate"],
         "status": lpa_data["status"],
+        "statusDate": lpa_data["statusDate"],
         "withdrawnDate": lpa_data["withdrawnDate"],
     }
 

--- a/lambda_functions/v1/openapi/lpa-openapi.yml
+++ b/lambda_functions/v1/openapi/lpa-openapi.yml
@@ -210,6 +210,7 @@ paths:
                   - registrationDate
                   - rejectedDate
                   - status
+                  - statusDate
                   - withdrawnDate
                   - dispatchDate
                 properties:
@@ -245,6 +246,12 @@ paths:
                     format: date
                     nullable: true
                     description: The date the LPA was registered
+                    example: '2018-06-30'
+                  statusDate:
+                    type: string
+                    format: date
+                    nullable: true
+                    description: The date the LPA's status was last changed
                     example: '2018-06-30'
                   withdrawnDate:
                     type: string
@@ -324,6 +331,7 @@ paths:
                   - registrationDate
                   - rejectedDate
                   - status
+                  - statusDate
                   - withdrawnDate
                   - dispatchDate
                 properties:
@@ -347,6 +355,12 @@ paths:
                     format: date
                     nullable: true
                     description: The date the LPA was registered
+                    example: '2018-06-30'
+                  statusDate:
+                    type: string
+                    format: date
+                    nullable: true
+                    description: The date the LPA's status was last changed
                     example: '2018-06-30'
                   withdrawnDate:
                     type: string

--- a/lambda_functions/v1/tests/test_data/lpa_online_tool_response.json
+++ b/lambda_functions/v1/tests/test_data/lpa_online_tool_response.json
@@ -7,5 +7,6 @@
     "registrationDate": null,
     "rejectedDate": null,
     "status": "Pending",
+    "statusDate": "2017-04-21",
     "withdrawnDate": null
 }

--- a/mock_sirius_backend/api/lpas/mock_data/lpa_online_tool_response.json
+++ b/mock_sirius_backend/api/lpas/mock_data/lpa_online_tool_response.json
@@ -98,6 +98,7 @@
         "rejectedDate": null,
         "replacementAttorneys": [],
         "status": "Pending",
+        "statusDate": "2014-10-15",
         "trustCorporations": [
             {
                 "addresses": [

--- a/mock_sirius_backend/sirius_public_api.yaml
+++ b/mock_sirius_backend/sirius_public_api.yaml
@@ -305,6 +305,7 @@ definitions:
       - withdrawnDate
       - dispatchDate
       - status
+      - statusDate
       - caseAttorneySingular
       - caseAttorneyJointlyAndSeverally
       - caseAttorneyJointly
@@ -360,6 +361,11 @@ definitions:
         type: string
         format: date
         description: The date the LPA was marked invalid
+        example: '2018-06-30'
+      statusDate:
+        type: string
+        format: date
+        description: The date the LPA's status was last changed
         example: '2018-06-30'
       withdrawnDate:
         type: string


### PR DESCRIPTION
## Purpose

It denotes when the status was last changed. This field has just started being populated by Sirius.

For VEGA-1055 #minor

## Approach

I added it everywhere a `withdrawnDate` is set.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
  * I've never got them to work
