### PR TITLE
Handle 410 response correctly

### DIFF
--- a/lambda_functions/v1/functions/lpa/app/api/handlers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/handlers.py
@@ -26,7 +26,7 @@ def get_by_online_tool_id(lpa_online_tool_id):
             try:
                 response = format_online_tool_response(sirius_response=sirius_response) \
                     if sirius_status_code == 200 \
-                    else sirius_response[0]
+                    else ""
 
                 return response, sirius_status_code
             except Exception as e:

--- a/lambda_functions/v1/tests/routes/conftest.py
+++ b/lambda_functions/v1/tests/routes/conftest.py
@@ -116,9 +116,7 @@ def patched_send_request_to_sirius(monkeypatch):
 
             for lpa in deleted_response_data["lpa"]:
                 if test_id in lpa["onlineLpaId"]:
-                    response_data = [lpa]
-
-                    return 410, response_data
+                    return 410, {"detail": "LPA with uid " + test_id + "has been deleted"}
 
         elif test_id[:5] == "crash":
             print("oh no you crashed sirius")

--- a/lambda_functions/v1/tests/routes/test_lpa_online_tool.py
+++ b/lambda_functions/v1/tests/routes/test_lpa_online_tool.py
@@ -45,7 +45,10 @@ def test_lpa_online_tool_route_with_cache(
     if cache_expected:
         redis_entry = mock_redis.get(name=f"opg-data-lpa-local-{online_tool_id}-{expected_status_code}")
         print(f"redis: {redis_entry}")
-        assert response.get_json() == json.loads(redis_entry)[0]
+        if expected_status_code == 410:
+            assert response.get_json() == ""
+        else:
+            assert response.get_json() == json.loads(redis_entry)[0]
     else:
         assert mock_redis.exists(f"opg-data-lpa-local-{online_tool_id}-{expected_status_code}") == 0
 

--- a/mock_sirius_backend/api/lpas/handlers.py
+++ b/mock_sirius_backend/api/lpas/handlers.py
@@ -31,8 +31,7 @@ def handle_lpa_get(query_params):
 
             for result in response_data_deleted["results"]:
                 if result["onlineLpaId"] in lpa_online_tool_id:
-                    response = [result]
-                    return 410, response
+                    return 410, {"detail": "LPA with uid " + lpa_online_tool_id + "has been deleted"}
 
         elif lpa_online_tool_id[:5] == "crash":
             print("oh no you crashed sirius")
@@ -75,8 +74,7 @@ def handle_lpa_get(query_params):
 
             for result in response_data_deleted["results"]:
                 if result["uId"] in case_id:
-                    response = [result]
-                    return 410, response
+                    return 410, {"detail": "LPA with uid " + case_id + "has been deleted"}
 
         elif len(sirius_uid) == 3:
             print("oh no you crashed sirius")


### PR DESCRIPTION
## Purpose

A 410 response is an object with a detail, so was failing to do an array access. However, we don't need to return any further detail, so just return an empty string for 410 responses.

Also updates mocks/tests to match.

## Approach

I considered returning the error content (i.e. `response = sirius_response`) but there's no need to pass the data downstream and it's just another contract to maintain.

## Learning

- The API Gateway console doesn't work for testing endpoints because Flask requires all paths to have a `/v1` prefix and the console doesn't add this
- The OpenAPI spec is inaccurate about error messages

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [x] I have run the integration tests (results below)
  * N/A they don't work
