### PR TITLE
UML-2341 - Cache results in production for 7 days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.idea
 __pycache__/
 *.pyc
+.python-version
 
 # Terraform
 **/terraform.tfstate*

--- a/integration_tests/v1/conftest.py
+++ b/integration_tests/v1/conftest.py
@@ -36,25 +36,25 @@ opg_sirius_api_gateway_dev_aws = {
 opg_data_lpa_dev_aws = {
     "name": "new collections api on aws dev",
     "healthcheck_endpoint": {
-        "url": "https://uml-2131.dev.lpa.api.opg.service.justice.gov.uk/v1/healthcheck",
+        "url": "https://uml-2341.dev.lpa.api.opg.service.justice.gov.uk/v1/healthcheck",
         "method": "GET",
     },
     "online_tool_endpoint": {
-        "url": "https://uml-2131.dev.lpa.api.opg.service.justice.gov.uk/v1/lpa"
+        "url": "https://uml-2341.dev.lpa.api.opg.service.justice.gov.uk/v1/lpa"
         "-online-tool/lpas",
         "method": "GET",
         "valid_lpa_online_tool_ids": ["A33718377316"],
         "invalid_lpa_online_tool_ids": ["banana"],
     },
     "use_an_lpa_endpoint": {
-        "url": "https://uml-2131.dev.lpa.api.opg.service.justice.gov.uk/v1/use"
+        "url": "https://uml-2341.dev.lpa.api.opg.service.justice.gov.uk/v1/use"
         "-an-lpa/lpas",
         "method": "GET",
         "valid_sirius_uids": ["700000000047"],
         "invalid_sirius_uids": ["9"],
     },
     "request_code_endpoint": {
-        "url": "https://uml-2131.dev.lpa.api.opg.service.justice.gov.uk/v1/use-an-lpa/lpas/requestCode",
+        "url": "https://uml-2341.dev.lpa.api.opg.service.justice.gov.uk/v1/use-an-lpa/lpas/requestCode",
         "method": "POST",
         "valid_sirius_lpas": [
             {"caseUid": 700000000013, "actorUid": 700000000997},

--- a/lambda_functions/v1/functions/lpa/app/config.py
+++ b/lambda_functions/v1/functions/lpa/app/config.py
@@ -15,10 +15,10 @@ class Config(object):
 
     # caching
     REQUEST_CACHE_NAME = API_NAME
-    REQUEST_CACHING_TTL = 48
 
     REDIS_URL = os.environ.get("REDIS_URL")
     REQUEST_CACHING = os.environ.get("REQUEST_CACHING", default="disabled")
+    REQUEST_CACHING_TTL = os.environ.get("REQUEST_CACHING_TTL", default="48")
     REQUEST_TIMEOUT = float(os.environ.get("REQUEST_TIMEOUT", default="10"))
 
 

--- a/lambda_functions/v1/functions/lpa/app/config.py
+++ b/lambda_functions/v1/functions/lpa/app/config.py
@@ -18,7 +18,7 @@ class Config(object):
 
     REDIS_URL = os.environ.get("REDIS_URL")
     REQUEST_CACHING = os.environ.get("REQUEST_CACHING", default="disabled")
-    REQUEST_CACHING_TTL = os.environ.get("REQUEST_CACHING_TTL", default="48")
+    REQUEST_CACHING_TTL = int(os.environ.get("REQUEST_CACHING_TTL", default="48"))
     REQUEST_TIMEOUT = float(os.environ.get("REQUEST_TIMEOUT", default="10"))
 
 

--- a/terraform/environment/modules/lambda/lambda.tf
+++ b/terraform/environment/modules/lambda/lambda.tf
@@ -33,7 +33,7 @@ resource "aws_lambda_function" "lambda_function" {
       API_VERSION         = var.openapi_version
       SESSION_DATA        = var.account.session_data
       REQUEST_CACHING     = "enabled"
-      REQUEST_CACHING_TTL = var.account.request_caching_ttl
+      REQUEST_CACHING_TTL = tostring(var.account.request_caching_ttl)
       REQUEST_TIMEOUT     = "10"
       REDIS_URL           = var.redis_url
     }

--- a/terraform/environment/modules/lambda/lambda.tf
+++ b/terraform/environment/modules/lambda/lambda.tf
@@ -26,15 +26,16 @@ resource "aws_lambda_function" "lambda_function" {
   }
   environment {
     variables = {
-      SIRIUS_BASE_URL    = "http://api.${var.account.target_environment}.ecs"
-      SIRIUS_API_VERSION = "v1"
-      ENVIRONMENT        = var.account.account_mapping
-      LOGGER_LEVEL       = var.account.logger_level
-      API_VERSION        = var.openapi_version
-      SESSION_DATA       = var.account.session_data
-      REQUEST_CACHING    = "enabled"
-      REQUEST_TIMEOUT    = "10"
-      REDIS_URL          = var.redis_url
+      SIRIUS_BASE_URL     = "http://api.${var.account.target_environment}.ecs"
+      SIRIUS_API_VERSION  = "v1"
+      ENVIRONMENT         = var.account.account_mapping
+      LOGGER_LEVEL        = var.account.logger_level
+      API_VERSION         = var.openapi_version
+      SESSION_DATA        = var.account.session_data
+      REQUEST_CACHING     = "enabled"
+      REQUEST_CACHING_TTL = var.account.request_caching_ttl
+      REQUEST_TIMEOUT     = "10"
+      REDIS_URL           = var.redis_url
     }
   }
   tracing_config {

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -18,7 +18,7 @@
       "vpc_id": "vpc-faf2d99e",
       "logger_level": "DEBUG",
       "elasticache_count": 1,
-      "request_caching_ttl": 168
+      "request_caching_ttl": 48
     },
     "preproduction": {
       "account_id": "492687888235",

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -18,7 +18,7 @@
       "vpc_id": "vpc-faf2d99e",
       "logger_level": "DEBUG",
       "elasticache_count": 1,
-      "request_caching_ttl": 48
+      "request_caching_ttl": 168
     },
     "preproduction": {
       "account_id": "492687888235",

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -18,7 +18,7 @@
       "vpc_id": "vpc-faf2d99e",
       "logger_level": "DEBUG",
       "elasticache_count": 1,
-      "request_caching_ttl": 168
+      "request_caching_ttl": "168"
     },
     "preproduction": {
       "account_id": "492687888235",
@@ -34,7 +34,7 @@
       "vpc_id": "vpc-037acd53d9ce813b4",
       "logger_level": "INFO",
       "elasticache_count": 3,
-      "request_caching_ttl": 48
+      "request_caching_ttl": "48"
     },
     "production": {
       "account_id": "649098267436",
@@ -50,7 +50,7 @@
       "vpc_id": "vpc-6809cc0f",
       "logger_level": "INFO",
       "elasticache_count": 3,
-      "request_caching_ttl": 168
+      "request_caching_ttl": "168"
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -18,7 +18,7 @@
       "vpc_id": "vpc-faf2d99e",
       "logger_level": "DEBUG",
       "elasticache_count": 1,
-      "request_caching_ttl": "168"
+      "request_caching_ttl": 168
     },
     "preproduction": {
       "account_id": "492687888235",
@@ -34,7 +34,7 @@
       "vpc_id": "vpc-037acd53d9ce813b4",
       "logger_level": "INFO",
       "elasticache_count": 3,
-      "request_caching_ttl": "48"
+      "request_caching_ttl": 48
     },
     "production": {
       "account_id": "649098267436",
@@ -50,7 +50,7 @@
       "vpc_id": "vpc-6809cc0f",
       "logger_level": "INFO",
       "elasticache_count": 3,
-      "request_caching_ttl": "168"
+      "request_caching_ttl": 168
     }
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -17,7 +17,8 @@
       "target_environment": "integration",
       "vpc_id": "vpc-faf2d99e",
       "logger_level": "DEBUG",
-      "elasticache_count": 1
+      "elasticache_count": 1,
+      "request_caching_ttl": 48
     },
     "preproduction": {
       "account_id": "492687888235",
@@ -32,7 +33,8 @@
       "target_environment": "preproduction",
       "vpc_id": "vpc-037acd53d9ce813b4",
       "logger_level": "INFO",
-      "elasticache_count": 3
+      "elasticache_count": 3,
+      "request_caching_ttl": 48
     },
     "production": {
       "account_id": "649098267436",
@@ -47,7 +49,8 @@
       "target_environment": "production",
       "vpc_id": "vpc-6809cc0f",
       "logger_level": "INFO",
-      "elasticache_count": 3
+      "elasticache_count": 3,
+      "request_caching_ttl": 168
     }
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -9,16 +9,17 @@ variable "management_role" {
 variable "accounts" {
   type = map(
     object({
-      account_id         = string
-      account_mapping    = string
-      allowed_roles      = list(string)
-      is_production      = string
-      logger_level       = string
-      opg_hosted_zone    = string
-      vpc_id             = string
-      session_data       = string
-      target_environment = string
-      elasticache_count  = number
+      account_id          = string
+      account_mapping     = string
+      allowed_roles       = list(string)
+      is_production       = string
+      logger_level        = string
+      opg_hosted_zone     = string
+      vpc_id              = string
+      session_data        = string
+      target_environment  = string
+      elasticache_count   = number
+      request_caching_ttl = number
     })
   )
 }


### PR DESCRIPTION
## Purpose

Cache results in production for 7 days

Allow UaL to serve more customers when Sirius is unavailable by holding more request data for longer.

https://github.com/ministryofjustice/opg-data/blob/d7d04f9c3f748f2164bdbb5e2e2ce63de479bbb9/shared_code/sirius_service/opg_sirius_service/sirius_handler.py#L38

Fixes UML-2341

## Approach

- add terraform variable to configure request caching ttl
- set variable to be 7 days for production
- set env var in lambda for REQUEST_CACHING_TTL

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [x] I have performed a self-review of my own code
* ~I have added relevant logging with appropriate levels to my code~
* ~I have updated documentation where relevant~
* ~I have added tests to prove my work~
* [x] I have run the integration tests (results below)
