### PR TITLE
UML-2592 - Specify api ecs task role and operator as allowed roles

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -25,7 +25,8 @@
       "account_mapping": "preproduction",
       "allowed_roles": [
         "\"arn:aws:iam::987830934591:role/preproduction-api-task-role\"",
-        "\"arn:aws:iam::888228022356:role/preproduction-api-task-role\""
+        "\"arn:aws:iam::888228022356:role/preproduction-api-task-role\"",
+        "\"arn:aws:iam::888228022356:role/operator\""
       ],
       "is_production": "false",
       "opg_hosted_zone": "pre.lpa.api.opg.service.justice.gov.uk",
@@ -41,7 +42,8 @@
       "account_mapping": "production",
       "allowed_roles": [
         "\"arn:aws:iam::980242665824:role/production-api-task-role\"",
-        "\"arn:aws:iam::690083044361:role/production-api-task-role\""
+        "\"arn:aws:iam::690083044361:role/production-api-task-role\"",
+        "\"arn:aws:iam::690083044361:role/operator\""
       ],
       "is_production": "true",
       "opg_hosted_zone": "lpa.api.opg.service.justice.gov.uk",

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -25,7 +25,7 @@
       "account_mapping": "preproduction",
       "allowed_roles": [
         "\"arn:aws:iam::987830934591:role/preproduction-api-task-role\"",
-        "\"arn:aws:iam::888228022356:root\""
+        "\"arn:aws:iam::888228022356:role/preproduction-api-task-role\""
       ],
       "is_production": "false",
       "opg_hosted_zone": "pre.lpa.api.opg.service.justice.gov.uk",
@@ -41,7 +41,7 @@
       "account_mapping": "production",
       "allowed_roles": [
         "\"arn:aws:iam::980242665824:role/production-api-task-role\"",
-        "\"arn:aws:iam::690083044361:root\""
+        "\"arn:aws:iam::690083044361:role/production-api-task-role\""
       ],
       "is_production": "true",
       "opg_hosted_zone": "lpa.api.opg.service.justice.gov.uk",


### PR DESCRIPTION
## Purpose

Access policy for the api is too permissive in production for UaL

## Approach

- Specify the UaL api ecs task role for preproduction and production

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
