### PR TITLE
Bump flask from 1.1.4 to 2.2.5 in /mock_sirius_backend

### DIFF
--- a/mock_sirius_backend/requirements.txt
+++ b/mock_sirius_backend/requirements.txt
@@ -1,4 +1,4 @@
 connexion==2.7.0
-Flask==1.1.4
+Flask==2.2.5
 markupsafe==2.0.1
 requests


### PR DESCRIPTION
Move dp bot update into team.

Bumps [flask](https://github.com/pallets/flask) from 1.1.4 to 2.2.5.
- [Release notes](https://github.com/pallets/flask/releases)
- [Changelog](https://github.com/pallets/flask/blob/main/CHANGES.rst)
- [Commits](https://github.com/pallets/flask/compare/1.1.4...2.2.5)

---
updated-dependencies:
- dependency-name: flask dependency-type: direct:production ...

## Purpose

_Briefly describe the purpose of the change, and/or link to the ticket for context_

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
