### PR TITLE
SP-2160 - Add sirius synthetics role to allowed roles #minor

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -9,7 +9,8 @@
         "\"arn:aws:iam::050256574573:root\"",
         "\"arn:aws:iam::367815980639:root\"",
         "\"arn:aws:iam::888228022356:root\"",
-        "\"arn:aws:iam::987830934591:role/preproduction-api-task-role\""
+        "\"arn:aws:iam::987830934591:role/preproduction-api-task-role\"",
+        "\"arn:aws:iam::288342028542:role/synthetics-dev\""
       ],
       "is_production": "false",
       "opg_hosted_zone": "dev.lpa.api.opg.service.justice.gov.uk",
@@ -26,7 +27,8 @@
       "allowed_roles": [
         "\"arn:aws:iam::987830934591:role/preproduction-api-task-role\"",
         "\"arn:aws:iam::888228022356:role/preproduction-api-task-role\"",
-        "\"arn:aws:iam::888228022356:role/operator\""
+        "\"arn:aws:iam::888228022356:role/operator\"",
+        "\"arn:aws:iam::492687888235:role/synthetics-preproduction\""
       ],
       "is_production": "false",
       "opg_hosted_zone": "pre.lpa.api.opg.service.justice.gov.uk",
@@ -43,7 +45,8 @@
       "allowed_roles": [
         "\"arn:aws:iam::980242665824:role/production-api-task-role\"",
         "\"arn:aws:iam::690083044361:role/production-api-task-role\"",
-        "\"arn:aws:iam::690083044361:role/operator\""
+        "\"arn:aws:iam::690083044361:role/operator\"",
+        "\"arn:aws:iam::649098267436:role/synthetics-production\""
       ],
       "is_production": "true",
       "opg_hosted_zone": "lpa.api.opg.service.justice.gov.uk",


### PR DESCRIPTION
## Purpose

Allow sirius synthetics to call the api rather than assuming operator

## Approach

Add arn to allowed_roles list

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [x] I have run the integration tests (results below)
