### PR TITLE
UML-3396: Create metric alarm

### DIFF
--- a/terraform/environment/alerts.tf
+++ b/terraform/environment/alerts.tf
@@ -45,3 +45,25 @@ resource "aws_cloudwatch_metric_alarm" "rest_api_high_count" {
   threshold                 = 500
   treat_missing_data        = "notBreaching"
 }
+
+resource "aws_cloudwatch_metric_alarm" "rest_api_slow_response" {
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.rest_api.arn]
+  alarm_description   = "Average response time over a minute for LPA Data Rest API in ${terraform.workspace}"
+  alarm_name          = "lpa-${local.environment}-rest-api-slow-response"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = 2
+  dimensions = {
+    ApiName = "lpa-${terraform.workspace}"
+  }
+  evaluation_periods        = 2
+  insufficient_data_actions = []
+  metric_name               = "Latency"
+  namespace                 = "AWS/ApiGateway"
+  ok_actions                = [data.aws_sns_topic.rest_api.arn]
+  period                    = 60
+  statistic                 = "Average"
+  tags                      = {}
+  threshold                 = 3500
+  treat_missing_data        = "notBreaching"
+}


### PR DESCRIPTION
## Purpose

UML-3396 - Creates a metric alarm ready for PagerDuty Alert, alarming when the LPA Data API has significantly increased response times

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
