### PR TITLE
update request timeout

### DIFF
--- a/lambda_functions/v1/functions/lpa/app/config.py
+++ b/lambda_functions/v1/functions/lpa/app/config.py
@@ -19,7 +19,7 @@ class Config(object):
     REDIS_URL = os.environ.get("REDIS_URL")
     REQUEST_CACHING = os.environ.get("REQUEST_CACHING", default="disabled")
     REQUEST_CACHING_TTL = int(os.environ.get("REQUEST_CACHING_TTL", default="48"))
-    REQUEST_TIMEOUT = float(os.environ.get("REQUEST_TIMEOUT", default="10"))
+    REQUEST_TIMEOUT = float(os.environ.get("REQUEST_TIMEOUT", default="30"))
 
 
 class LocalMockConfig(Config):

--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -58,7 +58,7 @@ module "lambda_lpa_v1" {
     SESSION_DATA        = local.account.session_data
     REQUEST_CACHING     = "enabled"
     REQUEST_CACHING_TTL = tostring(local.account.request_caching_ttl)
-    REQUEST_TIMEOUT     = "10"
+    REQUEST_TIMEOUT     = "30"
     REDIS_URL           = aws_route53_record.lpa_redis.name
   }
 


### PR DESCRIPTION
## Purpose

Increase request timeout, due to errors seen with the integration since updating python to 3.13

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
