### PR TITLE
add github action renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "branchPrefix": "renovate-",
   "commitMessageAction": "Renovate Update",


### PR DESCRIPTION
Enable renovate to handle digest pinned github actions correctly