### PR TITLE
Fix demo environment hostname

### DIFF
--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -30,7 +30,7 @@
         "arn:aws:iam::288342028542:role/synthetics-dev"
       ],
       "is_production": "false",
-      "opg_hosted_zone": "dev.lpa.api.opg.service.justice.gov.uk",
+      "opg_hosted_zone": "demo.lpa.api.opg.service.justice.gov.uk",
       "session_data": "publicapi@opgtest.com",
       "target_environment": "demo",
       "vpc_id": "vpc-faf2d99e",


### PR DESCRIPTION
Because we're defining the environment, the hosted zone needs to be fully qualified.

For SP-2852 #patch
