### PR TITLE
Split account/environment setup

### DIFF
--- a/terraform/environment/lambda.tf
+++ b/terraform/environment/lambda.tf
@@ -51,7 +51,7 @@ module "lambda_lpa_v1" {
   })
 
   environment_variables = {
-    SIRIUS_BASE_URL     = "http://api.${local.account.target_environment}.ecs"
+    SIRIUS_BASE_URL     = "http://api.${local.target_environment}.ecs"
     SIRIUS_API_VERSION  = "v1"
     ENVIRONMENT         = local.account.account_mapping
     LOGGER_LEVEL        = local.account.logger_level

--- a/terraform/environment/locals.tf
+++ b/terraform/environment/locals.tf
@@ -1,10 +1,11 @@
 locals {
-  environment       = replace(terraform.workspace, "_", "-")
-  account           = contains(keys(var.accounts), local.environment) ? var.accounts[local.environment] : var.accounts.development
-  branch_build_flag = contains(keys(var.accounts), local.environment) ? false : true
-  a_record          = local.branch_build_flag ? lower("${local.environment}.${data.aws_route53_zone.environment_cert.name}") : lower(data.aws_route53_zone.environment_cert.name)
-  redis_c_name      = local.branch_build_flag ? lower("${local.environment}-redis.${data.aws_route53_zone.environment_cert.name}") : lower("redis.${data.aws_route53_zone.environment_cert.name}")
-  redis_c_rg_name   = substr(local.environment, 0, 26)
+  environment        = replace(terraform.workspace, "_", "-")
+  account            = contains(keys(var.accounts), local.environment) ? var.accounts[local.environment] : var.accounts.development
+  branch_build_flag  = contains(keys(var.accounts), local.environment) ? false : true
+  a_record           = local.branch_build_flag ? lower("${local.environment}.${data.aws_route53_zone.environment_cert.name}") : lower(data.aws_route53_zone.environment_cert.name)
+  redis_c_name       = local.branch_build_flag ? lower("${local.environment}-redis.${data.aws_route53_zone.environment_cert.name}") : lower("redis.${data.aws_route53_zone.environment_cert.name}")
+  redis_c_rg_name    = substr(local.environment, 0, 26)
+  target_environment = contains(keys(var.environment_mapping), local.environment) ? var.environment_mapping[local.environment] : var.environment_mapping.default
 
   default_tags = {
     business-unit          = "OPG"

--- a/terraform/environment/modules/stage/variables.tf
+++ b/terraform/environment/modules/stage/variables.tf
@@ -20,10 +20,6 @@ variable "rest_api" {}
 
 variable "tags" {}
 
-variable "target_environment" {
-  type = string
-}
-
 variable "vpc_id" {
   type = string
 }

--- a/terraform/environment/security_groups.tf
+++ b/terraform/environment/security_groups.tf
@@ -1,6 +1,6 @@
 data "aws_security_group" "lambda_api_ingress" {
   filter {
     name   = "tag:Name"
-    values = ["integration-lambda-api-access-${local.account.target_environment}"]
+    values = ["integration-lambda-api-access-${local.target_environment}"]
   }
 }

--- a/terraform/environment/stage.tf
+++ b/terraform/environment/stage.tf
@@ -33,15 +33,14 @@ resource "aws_api_gateway_domain_name" "lpa_data" {
 module "deploy_v1" {
   source = "./modules/stage"
 
-  account_name       = local.account.account_mapping
-  api_name           = local.api_name
-  aws_subnet_ids     = data.aws_subnet.private.*.id
-  environment        = local.environment
-  openapi_version    = "v1"
-  region_name        = data.aws_region.region.name
-  tags               = local.default_tags
-  target_environment = local.account.target_environment
-  vpc_id             = local.account.vpc_id
+  account_name    = local.account.account_mapping
+  api_name        = local.api_name
+  aws_subnet_ids  = data.aws_subnet.private.*.id
+  environment     = local.environment
+  openapi_version = "v1"
+  region_name     = data.aws_region.region.name
+  tags            = local.default_tags
+  vpc_id          = local.account.vpc_id
   //Modify here for new version - point to different version
   domain_name                 = aws_api_gateway_domain_name.lpa_data
   lpa_lambda_function_name    = module.lambda_lpa_v1.lambda_function_name

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -14,25 +14,6 @@
       "is_production": "false",
       "opg_hosted_zone": "dev.lpa.api.opg.service.justice.gov.uk",
       "session_data": "publicapi@opgtest.com",
-      "target_environment": "integration",
-      "vpc_id": "vpc-faf2d99e",
-      "logger_level": "INFO",
-      "elasticache_count": 1,
-      "request_caching_ttl": 48
-    },
-    "demo": {
-      "account_id": "288342028542",
-      "account_mapping": "development",
-      "allowed_roles": [
-        "arn:aws:iam::288342028542:role/operator",
-        "arn:aws:iam::288342028542:root",
-        "arn:aws:iam::367815980639:root",
-        "arn:aws:iam::288342028542:role/synthetics-dev"
-      ],
-      "is_production": "false",
-      "opg_hosted_zone": "demo.lpa.api.opg.service.justice.gov.uk",
-      "session_data": "publicapi@opgtest.com",
-      "target_environment": "demo",
       "vpc_id": "vpc-faf2d99e",
       "logger_level": "INFO",
       "elasticache_count": 1,
@@ -50,7 +31,6 @@
       "is_production": "false",
       "opg_hosted_zone": "pre.lpa.api.opg.service.justice.gov.uk",
       "session_data": "opg+publicapi@digital.justice.gov.uk",
-      "target_environment": "preproduction",
       "vpc_id": "vpc-037acd53d9ce813b4",
       "logger_level": "INFO",
       "elasticache_count": 3,
@@ -68,11 +48,16 @@
       "is_production": "true",
       "opg_hosted_zone": "lpa.api.opg.service.justice.gov.uk",
       "session_data": "opg+publicapi@digital.justice.gov.uk",
-      "target_environment": "production",
       "vpc_id": "vpc-6809cc0f",
       "logger_level": "INFO",
       "elasticache_count": 3,
       "request_caching_ttl": 168
     }
+  },
+  "environment_mapping": {
+    "default": "integration",
+    "demo": "demo",
+    "preproduction": "preproduction",
+    "production": "production"
   }
 }

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -17,11 +17,14 @@ variable "accounts" {
       opg_hosted_zone     = string
       vpc_id              = string
       session_data        = string
-      target_environment  = string
       elasticache_count   = number
       request_caching_ttl = number
     })
   )
+}
+
+variable "environment_mapping" {
+  type = map(string)
 }
 
 variable "lambda_image_uri" {

--- a/terraform/environment/versions.tf
+++ b/terraform/environment/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = "1.11.4"
+  required_version = "1.12.1"
 }


### PR DESCRIPTION
The original set up of this assumed complete alignment between accounts and environments, but with the new demo environment we now have configuration that is environment-specific.

Therefore, remove the "demo" account configuration and introduce specific configuration for environment mapping.

Remove the `target_environment` variable from the "stage" module because it isn't used for anything.

For SP-2852 #patch
