### PR TITLE
UML-3873: remove aws-lambda-rie

### DIFF
--- a/lambda_functions/v1/Dockerfile-Function
+++ b/lambda_functions/v1/Dockerfile-Function
@@ -1,8 +1,10 @@
-FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058
+FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058 as build
 
-COPY lambda_functions/v1/functions/lpa/ ${LAMBDA_TASK_ROOT}
+WORKDIR /var/task
 
-COPY lambda_functions/v1/requirements/requirements.txt requirements.txt
+COPY ./functions/lpa/ .
+
+COPY ./requirements/requirements.txt requirements.txt
 
 RUN pip install -r requirements.txt
 
@@ -10,5 +12,11 @@ RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever && \
     dnf clean all && \
     dnf -y update sqlite-libs libxml2 && \
     dnf clean all
+
+FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058 as runtime
+
+COPY --from=build /var/task ${LAMBDA_TASK_ROOT}
+
+RUN rm -f /usr/local/bin/aws-lambda-rie
 
 CMD [ "app.lpa.lambda_handler" ]

--- a/lambda_functions/v1/Dockerfile-Function
+++ b/lambda_functions/v1/Dockerfile-Function
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058 as build
+FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058 AS build
 
 WORKDIR /var/task
 
@@ -13,7 +13,7 @@ RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever && \
     dnf -y update sqlite-libs libxml2 && \
     dnf clean all
 
-FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058 as runtime
+FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058 AS runtime
 
 COPY --from=build /var/task ${LAMBDA_TASK_ROOT}
 

--- a/lambda_functions/v1/Dockerfile-Function
+++ b/lambda_functions/v1/Dockerfile-Function
@@ -2,9 +2,9 @@ FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe60864
 
 WORKDIR /var/task
 
-COPY ./functions/lpa/ .
+COPY lambda_functions/v1/functions/lpa/ .
 
-COPY ./requirements/requirements.txt requirements.txt
+COPY lambda_functions/v1/requirements/requirements.txt requirements.txt
 
 RUN pip install -r requirements.txt
 

--- a/lambda_functions/v1/Dockerfile-Function
+++ b/lambda_functions/v1/Dockerfile-Function
@@ -1,12 +1,12 @@
 FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058 AS build
 
-WORKDIR /var/task
-
-COPY lambda_functions/v1/functions/lpa/ .
+WORKDIR /app
 
 COPY lambda_functions/v1/requirements/requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt -t python/
+
+COPY lambda_functions/v1/functions/lpa/ python/
 
 RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever && \
     dnf clean all && \
@@ -15,7 +15,9 @@ RUN echo "2023.7.20250512" > /etc/dnf/vars/releasever && \
 
 FROM public.ecr.aws/lambda/python:3.13.2025.08.15.14@sha256:308f4e536a543fe608649a4cb552203c695dda353b7b5aea15d1bd053aa36058 AS runtime
 
-COPY --from=build /var/task ${LAMBDA_TASK_ROOT}
+WORKDIR /var/task
+
+COPY --from=build /app/python ./
 
 RUN rm -f /usr/local/bin/aws-lambda-rie
 


### PR DESCRIPTION
## Purpose

Remove the aws-lambda-rie causing a high cve

## Approach

Create a mutli stage docker build so that we can remove the lambda-rie from production, whilst maintaining the ability to run the image locally

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
