### PR TITLE
Move opg_sirius_service into repo

### DIFF
--- a/lambda_functions/v1/functions/lpa/app/__init__.py
+++ b/lambda_functions/v1/functions/lpa/app/__init__.py
@@ -4,7 +4,7 @@ from flask import Flask
 
 from .api.resources import api as api_blueprint
 
-from opg_sirius_service.sirius_handler import SiriusService
+from .opg_sirius_service.sirius_handler import SiriusService
 from .config import Config
 
 

--- a/lambda_functions/v1/functions/lpa/app/opg_sirius_service/sirius_handler.py
+++ b/lambda_functions/v1/functions/lpa/app/opg_sirius_service/sirius_handler.py
@@ -1,0 +1,276 @@
+import datetime
+import json
+from urllib.parse import urlencode, quote
+
+import boto3
+import jwt
+import localstack_client.session
+import requests
+from botocore.exceptions import ClientError
+
+import logging
+
+logger = logging
+
+
+class SiriusService:
+    def __init__(self, config_params, cache):
+        try:
+            self.cache = cache
+            self.use_cache = False
+            self.sirius_base_url = config_params.SIRIUS_BASE_URL
+            self.environment = config_params.ENVIRONMENT
+            self.session_data = config_params.SESSION_DATA
+            self.request_timeout = config_params.REQUEST_TIMEOUT
+            self.request_caching = (
+                config_params.REQUEST_CACHING if cache else "disabled"
+            )
+            self.request_caching_name = (
+                config_params.REQUEST_CACHE_NAME
+                if config_params.REQUEST_CACHE_NAME
+                else "default_sirius_cache"
+            )
+            self.request_caching_ttl = (
+                config_params.REQUEST_CACHING_TTL
+                if config_params.REQUEST_CACHING_TTL
+                else 48
+            )
+        except Exception as e:
+            raise Exception(f"Error loading config e: {e}")
+
+    def build_sirius_url(self, endpoint, url_params=None):
+        """
+        Builds the url for the endpoint from variables (probably saved in env vars)
+
+        Args:
+            base_url: URL of the Sirius server
+            api_route: path to public api
+            endpoint: endpoint
+        Returns:
+            string: url
+        """
+
+        base_url = self.sirius_base_url
+
+        sirius_url = f"{base_url}/{quote(endpoint)}"
+
+        if url_params:
+            encoded_params = urlencode(url_params)
+            url = f"{sirius_url}?{encoded_params}"
+        else:
+            url = sirius_url
+
+        return url
+
+    def _get_secret(self):
+        """
+        Gets and decrypts the JWT secret from AWS Secrets Manager for the chosen environment
+        This was c&p directly from AWS Secrets Manager...
+
+        Args:
+            environment: AWS environment name
+        Returns:
+            JWT secret
+        Raises:
+            ClientError
+        """
+
+        environment = self.environment
+        secret_name = f"{environment}/jwt-key"
+        region_name = "eu-west-1"
+
+        if environment == "local":  # pragma: no cover
+            logger.debug("Using local AWS Secrets Manager")  # pragma: no cover
+            current_session = localstack_client.session.Session()  # pragma: no cover
+
+        else:
+            current_session = boto3.session.Session()
+
+        client = current_session.client(
+            service_name="secretsmanager", region_name=region_name
+        )
+
+        try:
+            get_secret_value_response = client.get_secret_value(SecretId=secret_name)
+            secret = get_secret_value_response["SecretString"]
+        except ClientError as e:
+            raise Exception(f"Unable to get secret from Secrets Manager: {e}")
+
+        return secret
+
+    def _build_sirius_headers(self, content_type="application/json"):
+        """
+        Builds headers for Sirius request, including JWT auth
+
+        Args:
+            content_type: string, defaults to 'application/json'
+        Returns:
+            Header dictionary with content type and auth token
+        """
+
+        if not content_type:
+            content_type = "application/json"
+
+        session_data = self.session_data
+
+        encoded_jwt = jwt.encode(
+            {
+                "session-data": session_data,
+                "iat": datetime.datetime.utcnow(),
+                "exp": datetime.datetime.utcnow() + datetime.timedelta(seconds=3600),
+            },
+            self._get_secret(),
+            algorithm="HS256",
+        )
+
+        return {
+            "Content-Type": content_type,
+            "Authorization": "Bearer " + encoded_jwt,
+        }
+
+    def _handle_sirius_error(
+        self, error_code=None, error_message=None, error_details=None
+    ):
+        error_code = error_code if error_code else 500
+        error_message = (
+            error_message if error_message else "Unknown error talking to Sirius"
+        )
+
+        try:
+            error_details = error_details["detail"]
+
+        except (KeyError, TypeError):
+            error_details = (
+                str(error_details) if len(str(error_details)) > 0 else "None"
+            )
+
+        message = f"{error_message}, details: {str(error_details)}"
+        return error_code, message
+
+    def check_sirius_available(self):
+        healthcheck_url = f"{self.sirius_base_url}/api/health-check"
+        try:
+            return (
+                True
+                if requests.get(
+                    url=healthcheck_url, timeout=self.request_timeout
+                ).status_code
+                == 200
+                else False
+            )
+        except Exception as e:
+            logger.error(f"Sirius Unavailable: {e}")
+            return False
+
+    def check_cache_available(self):
+        try:
+            return self.cache.ping()
+        except Exception as e:
+            logger.error(f"Unable to connect to cache: {e}")
+            return False
+
+    def send_request_to_sirius(self, key, url, method, content_type=None, data=None):
+        cache_enabled = True if self.request_caching == "enabled" else False
+        self.use_cache = False
+        if self.check_sirius_available():
+            sirius_status_code, sirius_data = self._get_data_from_sirius(
+                url, method, content_type, data
+            )
+            logger.debug(f"sirius_status_code: {sirius_status_code}")
+            logger.debug(f"cache_enabled: {cache_enabled}")
+            logger.debug(f"method: {method}")
+            if cache_enabled and method == "GET":
+                if sirius_status_code == 200 or sirius_status_code == 410:
+                    logger.debug(f"Putting data in cache with key: {key}")
+                    self._put_sirius_data_in_cache(
+                        key=key, data=sirius_data, status=sirius_status_code
+                    )
+
+            return sirius_status_code, sirius_data
+        else:
+            if cache_enabled and method == "GET":
+                self.use_cache = True
+                logger.debug(f"Getting data from cache with key: {key}")
+                sirius_status_code, sirius_data = self._get_sirius_data_from_cache(
+                    key=key
+                )
+
+                return sirius_status_code, sirius_data
+            else:
+                sirius_status_code, sirius_data = self._handle_sirius_error(
+                    error_message="Unable to send request to Sirius",
+                    error_details="Sirius not available - cache not enabled or incorrect method for cache",
+                )
+                return sirius_status_code, sirius_data
+
+    def _get_data_from_sirius(self, url, method, content_type=None, data=None):
+        logger.debug("_get_data_from_sirius")
+        headers = self._build_sirius_headers(content_type)
+
+        try:
+            if method == "PUT":
+                r = requests.put(url=url, data=data, headers=headers)
+                return r.status_code, r.json()
+
+            elif method == "POST":
+                r = requests.post(url=url, data=data, headers=headers)
+                if r.status_code == 204:
+                    return r.status_code, ""
+
+                return r.status_code, r.json()
+            elif method == "GET":
+                r = requests.get(url=url, headers=headers, timeout=self.request_timeout)
+                return r.status_code, r.json()
+            else:
+                return self._handle_sirius_error(
+                    error_message="Unable to send request to Sirius",
+                    error_details=f"Method {method} not allowed on Sirius route",
+                )
+
+        except Exception as e:
+            return self._handle_sirius_error(
+                error_message="Unable to send request to Sirius", error_details=e
+            )
+
+    def _put_sirius_data_in_cache(self, key, data, status):
+        logger.debug("_put_sirius_data_in_cache")
+        cache_name = self.request_caching_name
+        cache_ref = f"{cache_name}-{key}"
+
+        cache_ttl_in_seconds = self.request_caching_ttl * 60 * 60
+
+        data = json.dumps(data)
+
+        try:
+            self.cache.set(
+                name=f"{cache_ref}-{status}", value=data, ex=cache_ttl_in_seconds
+            )
+            logger.debug(f"setting redis: {cache_ref}-{status}")
+        except Exception as e:
+            logger.error(f"Unable to set cache: {cache_ref}-{status}, error {e}")
+
+    def _get_sirius_data_from_cache(self, key):
+        cache_name = self.request_caching_name
+        cache_ref = f"{cache_name}-{key}"
+
+        try:
+            if self.cache.exists(f"{cache_ref}-200"):
+                logger.debug(f"found redis cache: {cache_ref}-200")
+                status_code = 200
+                result = self.cache.get(f"{cache_ref}-200")
+                result = json.loads(result)
+            elif self.cache.exists(f"{cache_ref}-410"):
+                logger.debug(f"found redis cache: {cache_ref}-410")
+                status_code = 410
+                result = self.cache.get(f"{cache_ref}-410")
+                result = json.loads(result)
+            else:
+                logger.debug(f"no-cache exists for: {cache_ref}-[200, 410]")
+                status_code = 500
+                result = None
+        except Exception as e:
+            logger.error(f"Unable to get from cache: {cache_ref}, error {e}")
+            status_code = 500
+            result = None
+
+        return status_code, result

--- a/lambda_functions/v1/requirements/dev-requirements.txt
+++ b/lambda_functions/v1/requirements/dev-requirements.txt
@@ -15,3 +15,4 @@ importlib-metadata==8.7.0
 opg-sirius-service==2.1.1
 typing-extensions==4.15.0
 pact-python==2.3.3
+boto3==1.26.13

--- a/lambda_functions/v1/requirements/requirements.txt
+++ b/lambda_functions/v1/requirements/requirements.txt
@@ -5,4 +5,4 @@ redis==6.4.0
 requests==2.32.5
 Werkzeug==3.1.3
 requests-aws4auth==1.0.1
-opg-sirius-service==2.1.1
+pyjwt==2.4.0

--- a/lambda_functions/v1/run-tests.sh
+++ b/lambda_functions/v1/run-tests.sh
@@ -2,6 +2,6 @@
 
 set -oe pipefail
 
-coverage run --source ${LAMBDA_TASK_ROOT}/lambda_functions/v1/functions/lpa/app/api -m pytest ${LAMBDA_TASK_ROOT}/lambda_functions/v1/tests
+coverage run --source ${LAMBDA_TASK_ROOT}/lambda_functions/v1/functions/lpa -m pytest ${LAMBDA_TASK_ROOT}/lambda_functions/v1/tests
 
 coverage report

--- a/lambda_functions/v1/tests/opg_sirius_service/conftest.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/conftest.py
@@ -1,0 +1,112 @@
+import string
+
+import fakeredis
+import pytest
+
+
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service.sirius_handler import (
+    SiriusService,
+)
+import requests
+
+
+from .default_config import SiriusServiceTestConfig
+
+max_examples = 50
+alphabet = list(string.ascii_letters + string.digits + string.punctuation)
+
+
+test_redis_handler = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+test_sirius_service = SiriusService(
+    config_params=SiriusServiceTestConfig, cache=test_redis_handler
+)
+
+
+@pytest.fixture()
+def patched_get_secret(monkeypatch):
+    def mock_secret(*args, **kwargs):
+        print("patched_get_secret returning mock_secret")
+        return "this_is_a_secret_string"
+
+    monkeypatch.setattr(test_sirius_service, "_get_secret", mock_secret)
+
+
+@pytest.fixture()
+def patched_build_sirius_headers(monkeypatch):
+    def mock_headers(*args, **kwargs):
+
+        return {
+            "Content-Type": args[0] if args[0] else "application/json",
+            "Authorization": "Bearer not-a-real-token",
+        }
+
+    monkeypatch.setattr(test_sirius_service, "_build_sirius_headers", mock_headers)
+
+
+@pytest.fixture()
+def patched_requests(monkeypatch):
+    def mock_get(*args, **kwargs):
+        print("mock GET")
+
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+
+        def json_func():
+            payload = {
+                "request_type": "get",
+                "headers": kwargs["headers"] if "headers" in kwargs else None,
+                "data": kwargs["data"] if "data" in kwargs else None,
+            }
+            return payload
+
+        mock_response.json = json_func
+
+        return mock_response
+
+    def mock_post(*args, **kwargs):
+        print("mock POST")
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+
+        def json_func():
+            payload = {
+                "request_type": "post",
+                "headers": kwargs["headers"] if "headers" in kwargs else None,
+                "data": kwargs["data"] if "data" in kwargs else None,
+            }
+            return payload
+
+        mock_response.json = json_func
+
+        return mock_response
+
+    def mock_put(*args, **kwargs):
+        print("mock PUT")
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+
+        def json_func():
+            payload = {
+                "request_type": "put",
+                "headers": kwargs["headers"] if "headers" in kwargs else None,
+                "data": kwargs["data"] if "data" in kwargs else None,
+            }
+            return payload
+
+        mock_response.json = json_func
+
+        return mock_response
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    monkeypatch.setattr(requests, "post", mock_post)
+    monkeypatch.setattr(requests, "put", mock_put)
+
+
+@pytest.fixture()
+def patched_requests_broken(monkeypatch):
+    def mock_broken_get(*args, **kwargs):
+        print("mock broken GET")
+
+        return None
+
+    monkeypatch.setattr(requests, "get", mock_broken_get)

--- a/lambda_functions/v1/tests/opg_sirius_service/default_config.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/default_config.py
@@ -1,0 +1,22 @@
+class SiriusServiceTestConfig:
+    # override prod values
+    DEBUG = True
+    TESTING = True
+    LOGGER_LEVEL = "DEBUG"
+    API_VERSION = "v1"
+    API_NAME = "opg-data-lpa"
+    ENVIRONMENT = "local"
+
+    SIRIUS_BASE_URL = "http://not-really-sirius.com"
+    SESSION_DATA = "publicapi@opgtest.com"
+
+    REQUEST_CACHING = "enabled"
+    REQUEST_CACHING_TTL = 48
+    REQUEST_CACHE_NAME = "opg-data-lpa-local"
+    REQUEST_TIMEOUT = 10
+    REDIS_URL = "redis://redis:6379"
+
+    # specific to local testing
+    HYPOTHESIS_MAX_EXAMPLES = 50
+    LOCALSTACK_HOST = "motoserver"
+    JWT_SECRET = "THIS_IS_MY_SECRET_KEY"  # pragma: allowlist secret

--- a/lambda_functions/v1/tests/opg_sirius_service/strategies.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/strategies.py
@@ -1,0 +1,72 @@
+from hypothesis import strategies as st
+from hypothesis.provisional import domains
+from yarl import URL
+
+
+def url():
+    """ Build http/https URL """
+    scheme = st.sampled_from(["http", "https"])
+    # Path must start with a slash
+    pathSt = st.builds(lambda x: "/" + x, st.text())
+    args = st.fixed_dictionaries(
+        {
+            "scheme": scheme,
+            "host": domains(),
+            "port": st.one_of(
+                st.none(), st.integers(min_value=10, max_value=2 ** 16 - 1)
+            ),
+            "path": pathSt,
+            "query_string": st.text(),
+            "fragment": st.text(),
+        }
+    )
+    return st.builds(lambda x: URL.build(**x), args)
+
+
+def url_as_string():
+    return st.builds(lambda x: str(x), url())
+
+
+content_types = {
+    "application": [
+        "java-archive",
+        "EDI-X12",
+        "EDIFACT",
+        "javascript",
+        "octet-stream",
+        "ogg",
+        "pdf",
+        "xhtml+xml",
+        "x-shockwave-flash",
+        "json",
+        "ld+json",
+        "xml",
+        "zip",
+        "x-www-form-urlencoded",
+    ],
+    "audio": ["mpeg", "x-ms-media"],
+    "image": [
+        "gif",
+        "jpeg",
+        "png",
+        "tiff",
+        "vnd.microsoft.icon",
+        "x-icon",
+        "vnd.djvu",
+        "svg+xml",
+    ],
+    "multipart": ["mixed", "alternative", "related", "form-data"],
+    "text": ["css", "csv", "html", "javascript", "plain", "xml"],
+    "video": ["mpeg", "mp4", "quicktime", "x-ms-wmv", "x-msvideo", "x-flv", "webm"],
+}
+
+
+@st.composite
+def content_type(draw):
+    main_type_list = [x for x in content_types.keys()]
+
+    type = draw(st.sampled_from(main_type_list))
+
+    subtype = draw(st.sampled_from(content_types[type]))
+
+    return f"{type}/{subtype}"

--- a/lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_headers.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_headers.py
@@ -1,0 +1,60 @@
+import jwt
+import pytest
+from hypothesis import given, example, settings, HealthCheck
+
+from .conftest import test_sirius_service
+from .strategies import content_type
+
+
+@pytest.mark.parametrize(
+    "test_content_type, test_secret_key, expected_content_type",
+    [
+        (None, "this_is_a_secret_string", "application/json"),
+        ("application/json", "this_is_a_secret_string", "application/json"),
+        ("application/pdf", "this_is_a_secret_string", "application/pdf"),
+    ],
+)
+def test_build_sirius_headers_content_type(
+    test_content_type, test_secret_key, expected_content_type, patched_get_secret
+):
+    if test_content_type:
+        headers = test_sirius_service._build_sirius_headers(
+            content_type=test_content_type
+        )
+    else:
+        headers = test_sirius_service._build_sirius_headers()
+
+    assert headers["Content-Type"] == expected_content_type
+
+
+def test_build_sirius_headers_auth(patched_get_secret):
+
+    headers = test_sirius_service._build_sirius_headers()
+    token = headers["Authorization"].split()[1]
+
+    try:
+        jwt.decode(token.encode("UTF-8"), "this_is_a_secret_string", algorithms="HS256")
+    except jwt.DecodeError as e:
+        pytest.fail(f"JWT is not encoded properly: {e}")
+
+    with pytest.raises(jwt.DecodeError):
+        jwt.decode(token.encode("UTF-8"), "this_is_the_wrong_key", algorithms="HS256")
+
+
+@given(test_content_type=content_type())
+@example(test_content_type=None)
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_build_sirius_headers_content_type_hypothesis(
+    test_content_type, patched_get_secret
+):
+    default_content_type = "application/json"
+
+    headers = test_sirius_service._build_sirius_headers(content_type=test_content_type)
+
+    if test_content_type:
+        assert headers["Content-Type"] == test_content_type
+    else:
+        assert headers["Content-Type"] == default_content_type
+
+        headers_no_content = test_sirius_service._build_sirius_headers()
+        assert headers_no_content["Content-Type"] == default_content_type

--- a/lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_url.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_url.py
@@ -1,7 +1,4 @@
-import logging
-
 import hypothesis.strategies as st
-import pytest
 import validators
 from hypothesis import given, settings, example, HealthCheck
 from .conftest import (
@@ -14,10 +11,9 @@ from .conftest import (
     endpoint=st.text(), url_params=st.dictionaries(st.text(), st.text()),
 )
 @example(
-    endpoint="v1/api/public/documents",
+    endpoint="v1/api/public/lpas",
     url_params={
-        "metadata[submission_id]": 11111,
-        "metadata[report_id]": "d0a43b67-3084-4a74-ab55-a7542cfadd37",
+        "lpa-online-tool-id": "A123567890",
     },
 )
 @settings(max_examples=max_examples, suppress_health_check=[HealthCheck.function_scoped_fixture])

--- a/lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_url.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_url.py
@@ -1,0 +1,29 @@
+import logging
+
+import hypothesis.strategies as st
+import pytest
+import validators
+from hypothesis import given, settings, example, HealthCheck
+from .conftest import (
+    max_examples,
+    test_sirius_service,
+)
+
+
+@given(
+    endpoint=st.text(), url_params=st.dictionaries(st.text(), st.text()),
+)
+@example(
+    endpoint="v1/api/public/documents",
+    url_params={
+        "metadata[submission_id]": 11111,
+        "metadata[report_id]": "d0a43b67-3084-4a74-ab55-a7542cfadd37",
+    },
+)
+@settings(max_examples=max_examples, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_build_sirius_url_with_hypothesis(endpoint, url_params, caplog):
+
+    print(f"endpoint: {endpoint}")
+    url = test_sirius_service.build_sirius_url(endpoint, url_params)
+
+    assert validators.url(url)

--- a/lambda_functions/v1/tests/opg_sirius_service/test_cache_available.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_cache_available.py
@@ -1,0 +1,35 @@
+import fakeredis
+
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service.sirius_handler import (
+    SiriusService,
+)
+from .default_config import SiriusServiceTestConfig
+
+
+def test_check_cache_available():
+    fake_redis_server = fakeredis.FakeServer()
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True, server=fake_redis_server
+    )
+    test_sirius_service = SiriusService(
+        config_params=SiriusServiceTestConfig, cache=test_redis_handler
+    )
+
+    result = test_sirius_service.check_cache_available()
+
+    assert result is True
+
+
+def test_check_cache_not_available():
+    fake_redis_server = fakeredis.FakeServer()
+    fake_redis_server.connected = False
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True, server=fake_redis_server
+    )
+    test_sirius_service = SiriusService(
+        config_params=SiriusServiceTestConfig, cache=test_redis_handler
+    )
+
+    result = test_sirius_service.check_cache_available()
+
+    assert result is False

--- a/lambda_functions/v1/tests/opg_sirius_service/test_constructor.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_constructor.py
@@ -1,0 +1,52 @@
+import fakeredis
+import pytest
+
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service.sirius_handler import (
+    SiriusService,
+)
+from .conftest import SiriusServiceTestConfig
+
+
+@pytest.mark.xfail(reason="unknown")
+def test_constructor():
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True
+    )
+    test_sirius_service = SiriusService(
+        config_params=SiriusServiceTestConfig, cache=test_redis_handler
+    )
+    print(f"test_sirius_service: {test_sirius_service}")
+
+    assert test_sirius_service.cache is not None
+    assert test_sirius_service.sirius_base_url is not None
+    assert test_sirius_service.environment is not None
+    assert test_sirius_service.session_data is not None
+    assert test_sirius_service.request_caching is not None
+    assert test_sirius_service.request_caching_name is not None
+    assert test_sirius_service.request_caching_ttl is not None
+
+
+def test_constructor_defaults():
+    class EmptyConfig(SiriusServiceTestConfig):
+        REQUEST_CACHE_NAME = None
+        REQUEST_CACHING_TTL = None
+
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True
+    )
+    test_sirius_service = SiriusService(
+        config_params=EmptyConfig, cache=test_redis_handler
+    )
+
+    assert test_sirius_service.request_caching_name == "default_sirius_cache"
+    assert test_sirius_service.request_caching_ttl == 48
+
+
+def test_constructor_redis_not_connected():
+
+    test_sirius_service = SiriusService(
+        config_params=SiriusServiceTestConfig, cache=None
+    )
+
+    print(f"test_sirius_service: {test_sirius_service}")
+    assert test_sirius_service.request_caching == "disabled"

--- a/lambda_functions/v1/tests/opg_sirius_service/test_get_data_from_sirius.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_get_data_from_sirius.py
@@ -1,0 +1,73 @@
+import json
+
+import hypothesis.strategies as st
+from hypothesis import given, settings, example, HealthCheck
+
+from .conftest import max_examples
+from .strategies import (
+    url_as_string,
+    content_type,
+)
+
+from .conftest import test_sirius_service
+
+
+@given(
+    url=url_as_string(),
+    method=st.sampled_from(["GET", "POST", "PUT"]),
+    content_type=content_type(),
+    data=st.dictionaries(st.text(), st.text()),
+)
+@example(url="http://not-an-url.com", method="GET", content_type=None, data=None)
+@example(url="http://not-an-url.com", method="POST", content_type=None, data=None)
+@example(url="http://not-an-url.com", method="PUT", content_type=None, data=None)
+@settings(max_examples=max_examples, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_get_data_from_sirius(
+    url, method, content_type, data, patched_build_sirius_headers, patched_requests
+):
+    default_content_type = "application/json"
+
+    result_status, result_data = test_sirius_service._get_data_from_sirius(
+        url=url, method=method, content_type=content_type, data=json.dumps(data)
+    )
+
+    assert result_status == 200
+    assert result_data["request_type"].lower() == method.lower()
+    if content_type:
+        assert result_data["headers"]["Content-Type"] == content_type
+    else:
+        assert result_data["headers"]["Content-Type"] == default_content_type
+    if method in ["POST", "PUT"]:
+        assert len(result_data["data"]) > 0
+    if method in ["GET"]:
+        assert result_data["data"] is None
+
+
+def test_get_data_from_sirius_bad_method(
+    patched_build_sirius_headers, patched_requests
+):
+    url = "http://not-an-url.com"
+    method = "banana"
+
+    result_status, result_data = test_sirius_service._get_data_from_sirius(
+        url=url, method=method
+    )
+
+    assert result_status == 500
+    assert (
+        result_data == f"Unable to send request to Sirius, details: Method "
+        f"{method} "
+        f"not allowed on Sirius route"
+    )
+
+
+def test_get_data_from_sirius_exception(
+    patched_build_sirius_headers, patched_requests_broken, caplog
+):
+    url = "http://not-an-url.com"
+    method = "GET"
+
+    result_status, result_data = test_sirius_service._get_data_from_sirius(
+        url=url, method=method
+    )
+    assert result_status == 500

--- a/lambda_functions/v1/tests/opg_sirius_service/test_get_secret.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_get_secret.py
@@ -1,0 +1,23 @@
+import boto3
+import pytest
+from moto import mock_aws
+
+from .conftest import test_sirius_service
+
+
+@pytest.mark.parametrize(
+    "secret_code, environment, region",
+    [("i_am_a_secret_code", "not_a_real_env", "eu-west-1")],
+)
+@mock_aws
+def test_get_secret(secret_code, environment, region):
+    session = boto3.session.Session()
+    client = session.client(service_name="secretsmanager", region_name=region)
+
+    client.create_secret(Name=f"{environment}/jwt-key", SecretString=secret_code)
+    test_sirius_service.environment = environment
+    assert test_sirius_service._get_secret() == secret_code
+
+    with pytest.raises(Exception):
+        test_sirius_service.environment = "not_the_right_env"
+        test_sirius_service._get_secret()

--- a/lambda_functions/v1/tests/opg_sirius_service/test_get_sirius_data_from_cache.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_get_sirius_data_from_cache.py
@@ -1,0 +1,97 @@
+import json
+
+import fakeredis
+import pytest
+import hypothesis.strategies as st
+from hypothesis import settings, given, HealthCheck
+
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service.sirius_handler import (
+    SiriusService,
+)
+from .conftest import (
+    max_examples,
+    alphabet,
+    test_sirius_service,
+)
+from .default_config import SiriusServiceTestConfig
+
+
+@given(
+    test_key_name=st.text(min_size=1, alphabet=alphabet),
+    test_key=st.text(min_size=1),
+    test_data=st.dictionaries(
+        st.text(min_size=1), st.text(min_size=1), min_size=1, max_size=10
+    ),
+)
+@settings(
+    max_examples=max_examples,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@pytest.mark.parametrize(
+    "http_status",
+    [
+        (200),
+        (410),
+    ],
+)
+def test_get_sirius_data_from_cache(
+    monkeypatch, test_key_name, test_key, test_data, http_status
+):
+
+    test_sirius_service.request_caching_name = test_key_name
+    test_cache = test_sirius_service.cache
+
+    full_key = f"{test_key_name}-{test_key}-{http_status}"
+    test_cache.set(name=full_key, value=json.dumps(test_data))
+
+    status_code, result_data = test_sirius_service._get_sirius_data_from_cache(
+        key=test_key
+    )
+
+    assert status_code == http_status
+    assert result_data == test_data
+
+    test_cache.flushall()
+
+
+def test_get_sirius_data_from_cache_key_does_not_exist(monkeypatch):
+
+    test_key_name = "test_key_name"
+    test_key = "test_key"
+
+    test_sirius_service.request_caching_name = test_key_name
+
+    test_cache = test_sirius_service.cache
+
+    status_code, result_data = test_sirius_service._get_sirius_data_from_cache(
+        key=test_key
+    )
+
+    assert status_code == 500
+    assert result_data is None
+
+    test_cache.flushall()
+
+
+def test_get_sirius_data_from_cache_cache_broken(caplog):
+
+    test_key = "test_key"
+
+    fake_redis_server = fakeredis.FakeServer()
+    fake_redis_server.connected = False
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True, server=fake_redis_server
+    )
+    test_sirius_service = SiriusService(
+        config_params=SiriusServiceTestConfig, cache=test_redis_handler
+    )
+
+    status_code, result_data = test_sirius_service._get_sirius_data_from_cache(
+        key=test_key
+    )
+
+    assert status_code == 500
+    assert result_data is None
+
+    with caplog.at_level("ERROR"):
+        assert "Unable to get from cache" in caplog.text

--- a/lambda_functions/v1/tests/opg_sirius_service/test_handle_sirius_error.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_handle_sirius_error.py
@@ -1,0 +1,41 @@
+import hypothesis.strategies as st
+from hypothesis import given, settings, HealthCheck
+
+
+from .conftest import (
+    max_examples,
+    test_sirius_service,
+)
+
+
+@given(
+    test_error_code=st.integers(min_value=0),
+    test_error_message=st.text(),
+    test_error_details=st.text(),
+)
+@settings(max_examples=max_examples, suppress_health_check=[HealthCheck.function_scoped_fixture])
+def test_handle_sirius_error_with_hypothesis(
+    caplog, test_error_code, test_error_message, test_error_details
+):
+    default_code = 500
+    default_message = "Unknown error talking to Sirius"
+    default_details = None
+
+    code, message = test_sirius_service._handle_sirius_error(
+        error_code=test_error_code,
+        error_message=test_error_message,
+        error_details=test_error_details,
+    )
+
+    if test_error_code == 0:
+        expected_code = default_code
+    else:
+        expected_code = test_error_code
+
+    expected_message = (
+        f"{test_error_message if test_error_message else default_message}, details: "
+        f"{test_error_details if test_error_details else default_details}"
+    )
+
+    assert code == expected_code
+    assert message == expected_message

--- a/lambda_functions/v1/tests/opg_sirius_service/test_put_sirius_data_in_cache.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_put_sirius_data_in_cache.py
@@ -1,0 +1,65 @@
+import json
+
+import fakeredis
+import hypothesis.strategies as st
+from hypothesis import settings, given, HealthCheck
+
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service.sirius_handler import (
+    SiriusService,
+)
+from .conftest import (
+    max_examples,
+    alphabet,
+    test_sirius_service,
+)
+from .default_config import SiriusServiceTestConfig
+
+test_cache = test_sirius_service.cache
+
+
+@given(
+    test_key_name=st.text(min_size=1, alphabet=alphabet),
+    test_key=st.text(min_size=1),
+    test_data=st.dictionaries(
+        st.text(min_size=1), st.text(min_size=1), min_size=1, max_size=10
+    ),
+    test_ttl=st.integers(min_value=1, max_value=100),
+)
+@settings(max_examples=max_examples)
+def test_put_sirius_data_in_cache(test_key_name, test_key, test_data, test_ttl):
+
+    test_sirius_service.request_caching_name = test_key_name
+    test_sirius_service.request_caching_ttl = test_ttl
+
+    test_sirius_service._put_sirius_data_in_cache(
+        key=test_key, data=json.dumps(test_data), status=200
+    )
+
+    full_key = f"{test_key_name}-{test_key}-200"
+
+    assert json.loads(json.loads(test_cache.get(full_key))) == test_data
+    assert test_cache.ttl(full_key) == test_ttl * 60 * 60
+
+    test_cache.flushall()
+
+
+def test_put_sirius_data_in_cache_broken(caplog):
+
+    test_key = "test_key"
+    test_data = {"test": "data"}
+
+    fake_redis_server = fakeredis.FakeServer()
+    fake_redis_server.connected = False
+    test_redis_handler = fakeredis.FakeStrictRedis(
+        charset="utf-8", decode_responses=True, server=fake_redis_server
+    )
+    test_sirius_service = SiriusService(
+        config_params=SiriusServiceTestConfig, cache=test_redis_handler
+    )
+
+    test_sirius_service._put_sirius_data_in_cache(
+        key=test_key, data=json.dumps(test_data), status="fail"
+    )
+
+    with caplog.at_level("ERROR"):
+        assert "Unable to set cache" in caplog.text

--- a/lambda_functions/v1/tests/opg_sirius_service/test_send_request_to_sirius.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_send_request_to_sirius.py
@@ -1,0 +1,266 @@
+import json
+
+import fakeredis
+import pytest
+
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service.sirius_handler import (
+    SiriusService,
+)
+from .conftest import SiriusServiceTestConfig
+
+test_redis_handler = fakeredis.FakeStrictRedis(charset="utf-8", decode_responses=True)
+test_sirius_service = SiriusService(
+    config_params=SiriusServiceTestConfig, cache=test_redis_handler
+)
+
+sirius_test_data = json.dumps({"sirius": "test_data"})
+key = "send_request_to_sirius"
+url = "http://not-an-url.com"
+full_key = f"{test_sirius_service.request_caching_name}-{key}"
+ttl = 48
+cache = test_sirius_service.cache
+
+
+@pytest.fixture()
+def mock_sirius_available(monkeypatch):
+    monkeypatch.setattr(test_sirius_service, "check_sirius_available", lambda: True)
+
+
+@pytest.fixture()
+def mock_sirius_not_available(monkeypatch):
+    monkeypatch.setattr(test_sirius_service, "check_sirius_available", lambda: False)
+
+
+@pytest.fixture()
+def mock_get_data_from_sirius_success(monkeypatch):
+    monkeypatch.setattr(
+        test_sirius_service,
+        "_get_data_from_sirius",
+        lambda x, y, z, p: (200, sirius_test_data),
+    )
+
+
+@pytest.fixture()
+def mock_get_data_from_sirius_deleted(monkeypatch):
+    monkeypatch.setattr(
+        test_sirius_service,
+        "_get_data_from_sirius",
+        lambda x, y, z, p: (410, sirius_test_data),
+    )
+
+
+@pytest.fixture()
+def mock_get_data_from_sirius_failed(monkeypatch):
+    monkeypatch.setattr(
+        test_sirius_service, "_get_data_from_sirius", lambda x, y, z, p: (500, "error")
+    )
+
+
+@pytest.mark.parametrize(
+    "method, cache_enabled, expected_status_code, cache_expected",
+    [
+        ("GET", "enabled", 200, True),
+        ("POST", "enabled", 200, False),
+        ("PUT", "enabled", 200, False),
+        ("GET", "disabled", 200, False),
+        ("POST", "disabled", 200, False),
+        ("PUT", "disabled", 200, False),
+        ("GET", "banana", 200, False),
+        ("GET", None, 200, False),
+    ],
+)
+def test_send_request_to_sirius_success(
+    monkeypatch,
+    caplog,
+    mock_sirius_available,
+    mock_get_data_from_sirius_success,
+    method,
+    cache_enabled,
+    expected_status_code,
+    cache_expected,
+):
+    test_sirius_service.request_caching = cache_enabled
+
+    result_status_code, result_data = test_sirius_service.send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    cache_key = f"{full_key}-{expected_status_code}"
+    if cache_expected:
+        print(f"full_key: {cache_key}")
+        print(f"cache.get(full_key): {cache.get(cache_key)}")
+        # print(f"json.loads(cache.get(full_key)): {json.loads(cache.get(full_key))}")
+        print(f"cache.scan(): {cache.scan()}")
+
+        assert json.loads(cache.get(cache_key)) == sirius_test_data
+        assert cache.ttl(cache_key) == ttl * 60 * 60
+
+    else:
+        assert cache.exists(cache_key) == 0
+
+    cache.flushall()
+
+
+@pytest.mark.parametrize(
+    "method, cache_enabled, expected_status_code, cache_expected",
+    [("GET", "enabled", 410, True), ("GET", "disabled", 410, False)],
+)
+def test_send_request_to_sirius_deleted(
+    monkeypatch,
+    caplog,
+    mock_sirius_available,
+    mock_get_data_from_sirius_deleted,
+    method,
+    cache_enabled,
+    expected_status_code,
+    cache_expected,
+):
+    test_sirius_service.request_caching = cache_enabled
+
+    result_status_code, result_data = test_sirius_service.send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    cache_key = f"{full_key}-{expected_status_code}"
+    if cache_expected:
+        print(f"full_key: {cache_key}")
+        print(f"cache.get(full_key): {cache.get(cache_key)}")
+        # print(f"json.loads(cache.get(full_key)): {json.loads(cache.get(full_key))}")
+        print(f"cache.scan(): {cache.scan()}")
+
+        assert json.loads(cache.get(cache_key)) == sirius_test_data
+        assert cache.ttl(cache_key) == ttl * 60 * 60
+
+    else:
+        assert cache.exists(cache_key) == 0
+
+    cache.flushall()
+
+
+# TODO should this 500 when the GET fails or should it try the cache?
+@pytest.mark.parametrize(
+    "method, cache_enabled, expected_status_code, cache_expected",
+    [
+        ("GET", "enabled", 500, False),
+        ("POST", "enabled", 500, False),
+        ("PUT", "enabled", 500, False),
+        ("GET", "disabled", 500, False),
+        ("POST", "disabled", 500, False),
+        ("PUT", "disabled", 500, False),
+    ],
+)
+def test_send_request_to_sirius_request_fails(
+    monkeypatch,
+    caplog,
+    mock_sirius_available,
+    mock_get_data_from_sirius_failed,
+    method,
+    cache_enabled,
+    expected_status_code,
+    cache_expected,
+):
+    test_sirius_service.request_caching = cache_enabled
+    result_status_code, result_data = test_sirius_service.send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    cache_key = f"{full_key}-{expected_status_code}"
+    if cache_expected:
+
+        assert json.loads(cache.get(cache_key)) == json.loads(sirius_test_data)
+        assert cache.ttl(cache_key) == ttl * 60 * 60
+
+    else:
+        assert cache.exists(cache_key) == 0
+    cache.flushall()
+
+
+@pytest.mark.parametrize(
+    "method, cache_enabled, expected_status_code, cache_expected",
+    [
+        ("GET", "enabled", 200, True),
+        ("GET", "enabled", 410, True),
+        ("POST", "enabled", 500, False),
+        ("PUT", "enabled", 500, False),
+        ("GET", "disabled", 500, False),
+        ("POST", "disabled", 500, False),
+        ("PUT", "disabled", 500, False),
+    ],
+)
+def test_send_request_to_sirius_but_sirius_is_broken_value_in_cache(
+    monkeypatch,
+    caplog,
+    mock_sirius_not_available,
+    mock_get_data_from_sirius_failed,
+    method,
+    cache_enabled,
+    expected_status_code,
+    cache_expected,
+):
+    cache_key = f"{full_key}-{expected_status_code}"
+
+    cache.set(name=f"{cache_key}", value=sirius_test_data, ex=ttl * 60 * 60)
+    print(f"cache.scan(): {cache.scan()}")
+
+    test_sirius_service.request_caching = cache_enabled
+
+    result_status_code, result_data = test_sirius_service.send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    if cache_expected:
+        print(f"json.loads(cache.get(cache_key)): {json.loads(cache.get(cache_key))}")
+
+        assert json.loads(cache.get(cache_key)) == json.loads(sirius_test_data)
+        assert cache.ttl(cache_key) == ttl * 60 * 60
+
+    cache.flushall()
+
+
+@pytest.mark.parametrize(
+    "method, cache_enabled, expected_status_code, cache_expected",
+    [
+        ("GET", "enabled", 500, False),
+        ("POST", "enabled", 500, False),
+        ("PUT", "enabled", 500, False),
+        ("GET", "disabled", 500, False),
+        ("POST", "disabled", 500, False),
+        ("PUT", "disabled", 500, False),
+    ],
+)
+def test_send_request_to_sirius_but_sirius_is_broken_value_not_in_cache(
+    monkeypatch,
+    caplog,
+    mock_sirius_not_available,
+    mock_get_data_from_sirius_failed,
+    method,
+    cache_enabled,
+    expected_status_code,
+    cache_expected,
+):
+    test_sirius_service.request_caching = cache_enabled
+
+    result_status_code, result_data = test_sirius_service.send_request_to_sirius(
+        key, url, method, content_type=None, data=None
+    )
+
+    assert result_status_code == expected_status_code
+
+    cache_key = f"{full_key}-{expected_status_code}"
+    if cache_expected:
+
+        assert json.loads(cache.get(cache_key)) == sirius_test_data
+        assert cache.ttl(cache_key) == ttl * 60 * 60
+
+    else:
+        assert cache.exists(cache_key) == 0
+
+    cache.flushall()

--- a/lambda_functions/v1/tests/opg_sirius_service/test_sirius_available.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_sirius_available.py
@@ -1,0 +1,54 @@
+import pytest
+import requests
+
+from .conftest import test_sirius_service
+
+
+@pytest.fixture
+def patched_sirius_heathcheck(monkeypatch):
+    def mock_healthcheck(*args, **kwargs):
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+
+        return mock_response
+
+    monkeypatch.setattr(requests, "get", mock_healthcheck)
+
+
+@pytest.fixture
+def patched_sirius_heathcheck_broken(monkeypatch):
+    def mock_healthcheck(*args, **kwargs):
+        mock_response = requests.Response()
+        mock_response.status_code = 404
+
+        return mock_response
+
+    monkeypatch.setattr(requests, "get", mock_healthcheck)
+
+
+@pytest.fixture
+def patched_sirius_heathcheck_exception(monkeypatch):
+    def mock_healthcheck(*args, **kwargs):
+        mock_response = requests.exceptions.ConnectionError()
+
+        return mock_response
+
+    monkeypatch.setattr(requests, "get", mock_healthcheck)
+
+
+def test_check_sirius_available(patched_sirius_heathcheck):
+    result = test_sirius_service.check_sirius_available()
+
+    assert result is True
+
+
+def test_check_sirius_not_available(patched_sirius_heathcheck_broken):
+    result = test_sirius_service.check_sirius_available()
+
+    assert result is False
+
+
+def test_check_sirius_healthcheck_throws(patched_sirius_heathcheck_exception):
+    result = test_sirius_service.check_sirius_available()
+
+    assert result is False

--- a/lambda_functions/v1/tests/routes/conftest.py
+++ b/lambda_functions/v1/tests/routes/conftest.py
@@ -7,7 +7,7 @@ from flask import Flask
 from lambda_functions.v1.functions.lpa.app import create_app
 from lambda_functions.v1.functions.lpa.app.config import LocalTestingConfig
 
-from opg_sirius_service import sirius_handler
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service import sirius_handler
 from lambda_functions.v1.tests.helpers import load_data
 from pact.v3 import Pact
 

--- a/lambda_functions/v1/tests/routes/test_healthcheck.py
+++ b/lambda_functions/v1/tests/routes/test_healthcheck.py
@@ -1,5 +1,5 @@
 import pytest
-from opg_sirius_service import sirius_handler
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service import sirius_handler
 
 
 @pytest.mark.parametrize(

--- a/lambda_functions/v1/tests/routes/test_lpa_online_tool.py
+++ b/lambda_functions/v1/tests/routes/test_lpa_online_tool.py
@@ -1,6 +1,6 @@
 import pytest
 
-from opg_sirius_service import sirius_handler
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service import sirius_handler
 from pact.v3 import match
 
 import json

--- a/lambda_functions/v1/tests/routes/test_request_code.py
+++ b/lambda_functions/v1/tests/routes/test_request_code.py
@@ -1,4 +1,4 @@
-from opg_sirius_service import sirius_handler
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service import sirius_handler
 from pact.v3 import match
 
 
@@ -84,7 +84,9 @@ def test_request_code_pact(
     )
 
     (
-        pact.upon_receiving("A request for a new code for actor 7000-2838-2199 on LPA 7000-3764-4871")
+        pact.upon_receiving(
+            "A request for a new code for actor 7000-2838-2199 on LPA 7000-3764-4871"
+        )
         .given("An LPA with UID 7000-3764-4871 exists")
         .with_request("post", "/api/public/v1/lpas/requestCode")
         .with_body(

--- a/lambda_functions/v1/tests/routes/test_use_an_lpa.py
+++ b/lambda_functions/v1/tests/routes/test_use_an_lpa.py
@@ -1,6 +1,6 @@
 import pytest
 
-from opg_sirius_service import sirius_handler
+from lambda_functions.v1.functions.lpa.app.opg_sirius_service import sirius_handler
 from pact.v3 import match
 
 import json


### PR DESCRIPTION
## Purpose

Copy files from opg-data which are only used in this repo. Co-locating the code will make it easier to understand and manage.

Fixes LPAL-1425 #patch

## Approach

Added two dependencies that weren't in this repo: pyjwt and boto3 (for testing).

Had to add `suppress_health_check=[HealthCheck.function_scoped_fixture]` to some tests so that the latest versions of hypothesis and pytest play nicely together.

Updated import paths to look in the new local location rather than treating it as an external dependency.

## Learning

I think we could improve the package/module structure of this repo, since everything is in a deeply-nested dir. It kind of forced me into putting the `opg_sirius_service` repo inside `./lpa/app`, which tripped me up a bit but seems fine.

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
  * N/A
* [x] I have updated documentation where relevant
  * N/A
* [x] I have added tests to prove my work
* [x] I have run the integration tests (results below)
