### PR TITLE
Remove content_type option from opg_sirius_service methods

### DIFF
--- a/integration_tests/v1/conftest.py
+++ b/integration_tests/v1/conftest.py
@@ -85,12 +85,11 @@ def send_a_request(
     method=None,
     payload=None,
     extra_headers=None,
-    content_type=None,
 ):
     print(f"Using test_config: {test_config['name']}")
 
     headers = {
-        "Content-Type": content_type if content_type else "application/json",
+        "Content-Type": "application/json",
     }
 
     if extra_headers:

--- a/lambda_functions/v1/functions/lpa/app/api/handlers.py
+++ b/lambda_functions/v1/functions/lpa/app/api/handlers.py
@@ -155,7 +155,6 @@ def request_code(body):
             key=None,
             url=sirius_url,
             method="POST",
-            content_type="application/json",
             data=json.dumps(body) if isinstance(body, dict) else body,
         )
     except Exception as e:

--- a/lambda_functions/v1/functions/lpa/app/opg_sirius_service/sirius_handler.py
+++ b/lambda_functions/v1/functions/lpa/app/opg_sirius_service/sirius_handler.py
@@ -98,18 +98,13 @@ class SiriusService:
 
         return secret
 
-    def _build_sirius_headers(self, content_type="application/json"):
+    def _build_sirius_headers(self):
         """
         Builds headers for Sirius request, including JWT auth
 
-        Args:
-            content_type: string, defaults to 'application/json'
         Returns:
             Header dictionary with content type and auth token
         """
-
-        if not content_type:
-            content_type = "application/json"
 
         session_data = self.session_data
 
@@ -124,7 +119,7 @@ class SiriusService:
         )
 
         return {
-            "Content-Type": content_type,
+            "Content-Type": "application/json",
             "Authorization": "Bearer " + encoded_jwt,
         }
 
@@ -169,12 +164,12 @@ class SiriusService:
             logger.error(f"Unable to connect to cache: {e}")
             return False
 
-    def send_request_to_sirius(self, key, url, method, content_type=None, data=None):
+    def send_request_to_sirius(self, key, url, method, data=None):
         cache_enabled = True if self.request_caching == "enabled" else False
         self.use_cache = False
         if self.check_sirius_available():
             sirius_status_code, sirius_data = self._get_data_from_sirius(
-                url, method, content_type, data
+                url, method, data
             )
             logger.debug(f"sirius_status_code: {sirius_status_code}")
             logger.debug(f"cache_enabled: {cache_enabled}")
@@ -203,9 +198,9 @@ class SiriusService:
                 )
                 return sirius_status_code, sirius_data
 
-    def _get_data_from_sirius(self, url, method, content_type=None, data=None):
+    def _get_data_from_sirius(self, url, method, data=None):
         logger.debug("_get_data_from_sirius")
-        headers = self._build_sirius_headers(content_type)
+        headers = self._build_sirius_headers()
 
         try:
             if method == "PUT":

--- a/lambda_functions/v1/tests/opg_sirius_service/conftest.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/conftest.py
@@ -36,7 +36,7 @@ def patched_build_sirius_headers(monkeypatch):
     def mock_headers(*args, **kwargs):
 
         return {
-            "Content-Type": args[0] if args[0] else "application/json",
+            "Content-Type": "application/json",
             "Authorization": "Bearer not-a-real-token",
         }
 

--- a/lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_headers.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_headers.py
@@ -1,30 +1,14 @@
 import jwt
 import pytest
-from hypothesis import given, example, settings, HealthCheck
 
 from .conftest import test_sirius_service
 from .strategies import content_type
 
 
-@pytest.mark.parametrize(
-    "test_content_type, test_secret_key, expected_content_type",
-    [
-        (None, "this_is_a_secret_string", "application/json"),
-        ("application/json", "this_is_a_secret_string", "application/json"),
-        ("application/pdf", "this_is_a_secret_string", "application/pdf"),
-    ],
-)
-def test_build_sirius_headers_content_type(
-    test_content_type, test_secret_key, expected_content_type, patched_get_secret
-):
-    if test_content_type:
-        headers = test_sirius_service._build_sirius_headers(
-            content_type=test_content_type
-        )
-    else:
-        headers = test_sirius_service._build_sirius_headers()
+def test_build_sirius_headers_content_type():
+    headers = test_sirius_service._build_sirius_headers()
 
-    assert headers["Content-Type"] == expected_content_type
+    assert headers["Content-Type"] == "application/json"
 
 
 def test_build_sirius_headers_auth(patched_get_secret):
@@ -39,22 +23,3 @@ def test_build_sirius_headers_auth(patched_get_secret):
 
     with pytest.raises(jwt.DecodeError):
         jwt.decode(token.encode("UTF-8"), "this_is_the_wrong_key", algorithms="HS256")
-
-
-@given(test_content_type=content_type())
-@example(test_content_type=None)
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
-def test_build_sirius_headers_content_type_hypothesis(
-    test_content_type, patched_get_secret
-):
-    default_content_type = "application/json"
-
-    headers = test_sirius_service._build_sirius_headers(content_type=test_content_type)
-
-    if test_content_type:
-        assert headers["Content-Type"] == test_content_type
-    else:
-        assert headers["Content-Type"] == default_content_type
-
-        headers_no_content = test_sirius_service._build_sirius_headers()
-        assert headers_no_content["Content-Type"] == default_content_type

--- a/lambda_functions/v1/tests/opg_sirius_service/test_send_request_to_sirius.py
+++ b/lambda_functions/v1/tests/opg_sirius_service/test_send_request_to_sirius.py
@@ -82,7 +82,7 @@ def test_send_request_to_sirius_success(
     test_sirius_service.request_caching = cache_enabled
 
     result_status_code, result_data = test_sirius_service.send_request_to_sirius(
-        key, url, method, content_type=None, data=None
+        key, url, method, data=None
     )
 
     assert result_status_code == expected_status_code
@@ -120,7 +120,7 @@ def test_send_request_to_sirius_deleted(
     test_sirius_service.request_caching = cache_enabled
 
     result_status_code, result_data = test_sirius_service.send_request_to_sirius(
-        key, url, method, content_type=None, data=None
+        key, url, method, data=None
     )
 
     assert result_status_code == expected_status_code
@@ -165,7 +165,7 @@ def test_send_request_to_sirius_request_fails(
 ):
     test_sirius_service.request_caching = cache_enabled
     result_status_code, result_data = test_sirius_service.send_request_to_sirius(
-        key, url, method, content_type=None, data=None
+        key, url, method, data=None
     )
 
     assert result_status_code == expected_status_code
@@ -211,7 +211,7 @@ def test_send_request_to_sirius_but_sirius_is_broken_value_in_cache(
     test_sirius_service.request_caching = cache_enabled
 
     result_status_code, result_data = test_sirius_service.send_request_to_sirius(
-        key, url, method, content_type=None, data=None
+        key, url, method, data=None
     )
 
     assert result_status_code == expected_status_code
@@ -249,7 +249,7 @@ def test_send_request_to_sirius_but_sirius_is_broken_value_not_in_cache(
     test_sirius_service.request_caching = cache_enabled
 
     result_status_code, result_data = test_sirius_service.send_request_to_sirius(
-        key, url, method, content_type=None, data=None
+        key, url, method, data=None
     )
 
     assert result_status_code == expected_status_code


### PR DESCRIPTION
The content-type is always `application/json` so there's no need to make it configurable

#patch