### PR TITLE
UML-4335: update renovate, pre-commit and workflows

### DIFF
--- a/.github/workflows/_destroy_environment.yml
+++ b/.github/workflows/_destroy_environment.yml
@@ -37,7 +37,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
-      - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # 1.0.8
       - name: "Parse terraform version [directory: ${{ env.tf_dir }}]"
         id: tf_version
         uses: ministryofjustice/opg-github-actions/actions/terraform-version@b605e1e2c94b399e8139c4c2be2c8730700e0004 # v4.5.2
@@ -57,9 +56,9 @@ jobs:
           role-to-assume: ${{ vars.OIDC_PULL_REQUEST_ROLE }}
           role-duration-seconds: 3600
           role-session-name: oidc-opg-data-lpa-destory-environment-github-action
-      - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+      - uses: ministryofjustice/opg-github-actions/actions/github-deploy-key@ceeda9d30ec7f6705c819d0b7664b9a79df99a3b # v4.8.0
         with:
-          ssh-private-key: ${{ secrets.allowlist_deploy_key }}
+          deploy_key: ${{ secrets.allowlist_deploy_key }}
       
       - name: Terraform Init
         run: terraform init -input=false

--- a/.github/workflows/_docker_build_scan_push.yml
+++ b/.github/workflows/_docker_build_scan_push.yml
@@ -99,6 +99,8 @@ jobs:
           SNYK_TEST_IMAGE: ${{ steps.docker_tags.outputs.semver_tag }}
           SNYK_TOKEN: ${{ secrets.SNYK_OPG_ORG_TOKEN }}
           snyk_policy_path: ./${{ matrix.data.snyk_policy_path }}
+          snyk_test_args: >
+            --severity-threshold=high
       
       - name: Upload Snyk scan results
         uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6

--- a/.github/workflows/_python_unit_tests.yml
+++ b/.github/workflows/_python_unit_tests.yml
@@ -37,14 +37,6 @@ jobs:
         with:
           python-version: "3.13"
 
-      - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # 1.0.8
-
-      - name: Install flake8
-        run: pip3 install flake8
-
-      - name: Run Flask8
-        run: 'flake8 --ignore Q000,W503 lambda_functions'
-
       - name: Build Unit Test Container
         run: docker compose build unit-test-lpa-data
 

--- a/.github/workflows/_terraform.yml
+++ b/.github/workflows/_terraform.yml
@@ -65,7 +65,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
-      - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # 1.0.8
       - name: "Parse terraform version [directory: ${{ env.tf_dir }}]"
         id: tf_version
         uses: ministryofjustice/opg-github-actions/actions/terraform-version@b605e1e2c94b399e8139c4c2be2c8730700e0004 # v4.5.2
@@ -85,9 +84,9 @@ jobs:
           role-to-assume: ${{ inputs.oidc_role }}
           role-duration-seconds: 3600
           role-session-name: environment-deploy-github-action
-      - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+      - uses: ministryofjustice/opg-github-actions/actions/github-deploy-key@ceeda9d30ec7f6705c819d0b7664b9a79df99a3b # v4.8.0
         with:
-          ssh-private-key: ${{ secrets.allowlist_deploy_key }}
+          deploy_key: ${{ secrets.allowlist_deploy_key }}
 
       - name: Terraform Init
         env:

--- a/.github/workflows/_terraform_lint.yml
+++ b/.github/workflows/_terraform_lint.yml
@@ -28,7 +28,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: "0"
-      - uses: unfor19/install-aws-cli-action@f5b46b7f32cf5e7ebd652656c5036bf83dd1e60c # 1.0.8
       - name: "Parse terraform version [directory: ${{ env.tf_dir }}]"
         id: tf_version
         uses: ministryofjustice/opg-github-actions/actions/terraform-version@b605e1e2c94b399e8139c4c2be2c8730700e0004 # v4.5.2
@@ -48,9 +47,9 @@ jobs:
           role-to-assume: ${{ inputs.oidc_role }}
           role-duration-seconds: 3600
           role-session-name: environment-deploy-github-action
-      - uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+      - uses: ministryofjustice/opg-github-actions/actions/github-deploy-key@ceeda9d30ec7f6705c819d0b7664b9a79df99a3b # v4.8.0
         with:
-          ssh-private-key: ${{ secrets.allowlist_deploy_key }}
+          deploy_key: ${{ secrets.allowlist_deploy_key }}
     
       - name: Format Terraform
         run: terraform fmt -check -recursive

--- a/.github/workflows/workflow_path_to_live.yml
+++ b/.github/workflows/workflow_path_to_live.yml
@@ -22,8 +22,8 @@ jobs:
     name: output workflow variables
     runs-on: ubuntu-latest
     outputs:
-      environment_terraform_version: ${{ steps.terraform_version_environment.outputs.version }}
       semver_tag: ${{ steps.semver_tag.outputs.tag }}
+      commit_sha: ${{ steps.commit_sha.outputs.sha }}
     steps:
       - name: checkout the project
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -40,6 +40,9 @@ jobs:
         with:
           prerelease: false
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit
+        id: commit_sha
+        run: echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
   terraform_lint:
     name: Lint & Validate Terraform

--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -44,7 +44,6 @@ jobs:
     name: output workflow variables
     runs-on: ubuntu-latest
     outputs:
-      environment_terraform_version: ${{ steps.terraform_version_environment.outputs.version }}
       semver_tag: ${{ steps.semver_tag.outputs.tag }}
       commit_sha: ${{ steps.commit_sha.outputs.sha }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,31 +9,20 @@ repos:
   #    description: Hook to validate Open API specs.
   #    language: python
   #    files: .*lpa-openapi.*\.(json|yaml|yml)
-  - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.32.0
-    hooks:
-      - id: yamllint
-        args: [-c=./.yamllint]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.81.0
+    rev: d0e12caebb2ab0ee8bf98181c8bfe9702bca103d  # frozen: v1.105.0
     hooks:
       - id: terraform_fmt
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: detect-private-key
-      - id: flake8
         args: ['--ignore=W503', '--exclude=docs/supportscripts/*']
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
-  - repo: https://github.com/ambv/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-        language_version: python3
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+    rev: 68e8b45440415753fff70a312ece8da92ba85b4a  # frozen: v1.5.0
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,14 @@
 {
-  "generated_at": "2021-07-30T10:54:59Z",
+  "version": "1.5.0",
   "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
     {
       "name": "AWSKeyDetector"
     },
     {
-      "name": "ArtifactoryDetector"
+      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -15,21 +18,54 @@
       "name": "BasicAuthDetector"
     },
     {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
@@ -38,46 +74,31 @@
       "name": "SoftlayerDetector"
     },
     {
+      "name": "SquareOAuthDetector"
+    },
+    {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
     }
   ],
-  "results": {
-    "docker-compose.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docker-compose.yml",
-        "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
-        "is_verified": false,
-        "line_number": 64
-      }
-    ]
-  },
-  "version": "1.5.0",
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
     },
     {
       "path": "detect_secrets.filters.heuristic.is_indirect_reference"
     },
     {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
     },
     {
       "path": "detect_secrets.filters.heuristic.is_lock_file"
@@ -86,7 +107,138 @@
       "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
     },
     {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
       "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
-  ]
+  ],
+  "results": {
+    ".pre-commit-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "384557cbc10c11a779cbe5ce8fd9838d2adf434b",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "26f89e75489173ffe046cc843b9a983e65020901",
+        "is_verified": false,
+        "line_number": 17
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "86242b7a7b67c1fd83514757a6b319602d648e94",
+        "is_verified": false,
+        "line_number": 25
+      }
+    ],
+    "docker-compose.yml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docker-compose.yml",
+        "hashed_secret": "dc724af18fbdd4e59189f5fe768a5f8311527050",
+        "is_verified": false,
+        "line_number": 39
+      }
+    ],
+    "lambda_functions/v1/openapi/lpa-openapi.yml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lambda_functions/v1/openapi/lpa-openapi.yml",
+        "hashed_secret": "a3a0c0d41960c4b2b58b4641bf7bac002045e80c",
+        "is_verified": false,
+        "line_number": 172
+      }
+    ],
+    "lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_url.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lambda_functions/v1/tests/opg_sirius_service/test_build_sirius_url.py",
+        "hashed_secret": "2258393723b33782a8039682e043ec4f1db3c2fa",
+        "is_verified": false,
+        "line_number": 11
+      }
+    ],
+    "lambda_functions/v1/tests/test_data/lpa_online_tool_deleted_response.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lambda_functions/v1/tests/test_data/lpa_online_tool_deleted_response.json",
+        "hashed_secret": "7c807c62ffa03e07a85a370f959f45fc48fa4d61",
+        "is_verified": false,
+        "line_number": 4
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lambda_functions/v1/tests/test_data/lpa_online_tool_deleted_response.json",
+        "hashed_secret": "cefbb2a7fd313b4c5f7751ff13972fffe0a303ff",
+        "is_verified": false,
+        "line_number": 7
+      }
+    ],
+    "lambda_functions/v1/tests/test_data/lpa_online_tool_successful_response.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lambda_functions/v1/tests/test_data/lpa_online_tool_successful_response.json",
+        "hashed_secret": "a2efb2a4331b130dcd136855794550c4def25622",
+        "is_verified": false,
+        "line_number": 7
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "lambda_functions/v1/tests/test_data/lpa_online_tool_successful_response.json",
+        "hashed_secret": "6fc17ff67497eef539c5fc528a26bd01d756163c",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "mock_sirius_backend/mock_data/lpa_online_tool_deleted_response.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "mock_sirius_backend/mock_data/lpa_online_tool_deleted_response.json",
+        "hashed_secret": "1167f459dc333f0313cbaa46c4e0c9cc4e59e72f",
+        "is_verified": false,
+        "line_number": 4
+      }
+    ],
+    "mock_sirius_backend/mock_data/lpa_online_tool_successful_response.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "mock_sirius_backend/mock_data/lpa_online_tool_successful_response.json",
+        "hashed_secret": "a2efb2a4331b130dcd136855794550c4def25622",
+        "is_verified": false,
+        "line_number": 97
+      }
+    ],
+    "mock_sirius_backend/sirius-config.yaml": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "mock_sirius_backend/sirius-config.yaml",
+        "hashed_secret": "a2efb2a4331b130dcd136855794550c4def25622",
+        "is_verified": false,
+        "line_number": 14
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "mock_sirius_backend/sirius-config.yaml",
+        "hashed_secret": "1167f459dc333f0313cbaa46c4e0c9cc4e59e72f",
+        "is_verified": false,
+        "line_number": 35
+      }
+    ]
+  },
+  "generated_at": "2026-04-09T13:08:16Z"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -43,7 +43,6 @@
       ],
       "prCreation": "immediate",
       "prPriority": 0,
-      "minimumReleaseAge": "3 days",
       "matchPackageNames": [
         "*"
       ]
@@ -61,7 +60,6 @@
       "schedule": [
         "after 6am and before 9am on Monday"
       ],
-      "minimumReleaseAge": "3 days",
       "matchPackageNames": [
         "/actions/*/"
       ]
@@ -76,6 +74,7 @@
     "rangeStrategy": "pin"
   },
   "branchConcurrentLimit": 5,
+  "minimumReleaseAge": "7 days",
   "prConcurrentLimit": 3,
   "prHourlyLimit": 1,
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Purpose

Updates Renovate to use a minimum release age of 7 days across all packages, and additionally pins pre-commit hooks to SHA's. 

We're also removing black and flake8 for the time being, as the repo is fairly low churn and it minimises risk for now.

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] I have run the integration tests (results below)
